### PR TITLE
feat: Sprint 4 — payments, financial reports, audit log, invoice filters

### DIFF
--- a/crates/api/src/handlers/audit.rs
+++ b/crates/api/src/handlers/audit.rs
@@ -1,0 +1,44 @@
+use axum::{
+    extract::{Extension, Query, State},
+    Json,
+};
+use oxidebooks_core::pagination::PageParams;
+use oxidebooks_db::repos::AuditRepo;
+use serde::Deserialize;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::Claims,
+    state::AppState,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct AuditQuery {
+    #[serde(flatten)]
+    pub page: PageParams,
+    pub resource_type: Option<String>,
+    pub resource_id: Option<String>,
+}
+
+/// GET /api/v1/audit-log
+pub async fn list_audit_log(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<AuditQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.has("audit:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let (events, next_cursor) = AuditRepo::list(
+        &state.db,
+        &claims.org,
+        q.resource_type.as_deref(),
+        q.resource_id.as_deref(),
+        &q.page,
+    )
+    .await?;
+    Ok(Json(serde_json::json!({
+        "data": events,
+        "pagination": { "has_next": next_cursor.is_some(), "next_cursor": next_cursor }
+    })))
+}

--- a/crates/api/src/handlers/contacts.rs
+++ b/crates/api/src/handlers/contacts.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use oxidebooks_core::models::{CreateContact, UpdateContact};
 use oxidebooks_core::pagination::PageParams;
-use oxidebooks_db::repos::ContactRepo;
+use oxidebooks_db::repos::{AuditRepo, ContactRepo};
 
 use crate::{
     error::{ApiError, ApiResult},
@@ -52,6 +52,16 @@ pub async fn create_contact(
         return Err(ApiError::Forbidden);
     }
     let contact = ContactRepo::create(&state.db, &claims.org, body).await?;
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "create",
+        "contact",
+        &contact.id,
+        None,
+    )
+    .await;
     Ok((
         StatusCode::CREATED,
         Json(serde_json::json!({ "data": contact })),
@@ -82,5 +92,15 @@ pub async fn delete_contact(
         return Err(ApiError::Forbidden);
     }
     ContactRepo::delete(&state.db, &claims.org, &id).await?;
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "delete",
+        "contact",
+        &id,
+        None,
+    )
+    .await;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/api/src/handlers/invoices.rs
+++ b/crates/api/src/handlers/invoices.rs
@@ -3,9 +3,10 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use oxidebooks_core::models::{CreateInvoice, UpdateInvoice};
+use oxidebooks_core::models::{CreateInvoice, InvoiceFilters, UpdateInvoice};
 use oxidebooks_core::pagination::PageParams;
-use oxidebooks_db::repos::InvoiceRepo;
+use oxidebooks_db::repos::{AuditRepo, InvoiceRepo};
+use serde::Deserialize;
 use tracing::info;
 
 use crate::{
@@ -14,16 +15,44 @@ use crate::{
     state::AppState,
 };
 
+#[derive(Debug, Deserialize)]
+pub struct InvoiceQuery {
+    #[serde(flatten)]
+    pub page: PageParams,
+    pub status: Option<String>,
+    #[serde(rename = "type")]
+    pub invoice_type: Option<String>,
+    pub contact_id: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+}
+
 /// GET /api/v1/invoices
 pub async fn list_invoices(
     State(state): State<AppState>,
     Extension(claims): Extension<Claims>,
-    Query(page): Query<PageParams>,
+    Query(q): Query<InvoiceQuery>,
 ) -> ApiResult<Json<serde_json::Value>> {
     if !claims.has("invoices:read") {
         return Err(ApiError::Forbidden);
     }
-    let (invoices, next_cursor) = InvoiceRepo::list(&state.db, &claims.org, &page).await?;
+
+    let parse_date = |s: &str| {
+        let fmt = time::macros::format_description!("[year]-[month]-[day]");
+        time::Date::parse(s, fmt)
+            .map_err(|_| ApiError::BadRequest(format!("invalid date '{s}'; expected YYYY-MM-DD")))
+    };
+
+    let filters = InvoiceFilters {
+        status: q.status,
+        invoice_type: q.invoice_type,
+        contact_id: q.contact_id,
+        from: q.from.as_deref().map(parse_date).transpose()?,
+        to: q.to.as_deref().map(parse_date).transpose()?,
+    };
+
+    let (invoices, next_cursor) =
+        InvoiceRepo::list(&state.db, &claims.org, &q.page, &filters).await?;
     Ok(Json(serde_json::json!({
         "data": invoices,
         "pagination": { "has_next": next_cursor.is_some(), "next_cursor": next_cursor }
@@ -53,6 +82,16 @@ pub async fn create_invoice(
         return Err(ApiError::Forbidden);
     }
     let invoice = InvoiceRepo::create(&state.db, &claims.org, body).await?;
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "create",
+        "invoice",
+        &invoice.id,
+        None,
+    )
+    .await;
     Ok((
         StatusCode::CREATED,
         Json(serde_json::json!({ "data": invoice })),
@@ -70,11 +109,16 @@ pub async fn update_invoice(
         return Err(ApiError::Forbidden);
     }
     let invoice = InvoiceRepo::update(&state.db, &claims.org, &id, body).await?;
-    info!(
-        invoice_id = %id,
-        org_id = %claims.org,
-        status = %invoice.status,
-        "📋 invoice updated"
-    );
+    info!(invoice_id = %id, org_id = %claims.org, status = %invoice.status, "invoice updated");
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "update",
+        "invoice",
+        &id,
+        None,
+    )
+    .await;
     Ok(Json(serde_json::json!({ "data": invoice })))
 }

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod accounts;
+pub mod audit;
 pub mod auth;
 pub mod auth_sso;
 pub mod contacts;
@@ -7,6 +8,7 @@ pub mod health;
 pub mod identity;
 pub mod invoices;
 pub mod organizations;
+pub mod payments;
 pub mod reports;
 pub mod roles;
 pub mod scim;

--- a/crates/api/src/handlers/payments.rs
+++ b/crates/api/src/handlers/payments.rs
@@ -1,0 +1,53 @@
+use axum::{
+    extract::{Extension, Path, State},
+    http::StatusCode,
+    Json,
+};
+use oxidebooks_core::models::{CreatePayment, VALID_METHODS};
+use oxidebooks_db::repos::PaymentRepo;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    middleware::Claims,
+    state::AppState,
+};
+
+/// POST /api/v1/invoices/:id/payments
+pub async fn create_payment(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(invoice_id): Path<String>,
+    Json(body): Json<CreatePayment>,
+) -> ApiResult<(StatusCode, Json<serde_json::Value>)> {
+    if !claims.has("invoices:write") {
+        return Err(ApiError::Forbidden);
+    }
+    if body.amount <= 0 {
+        return Err(ApiError::BadRequest("amount must be positive".into()));
+    }
+    if !VALID_METHODS.contains(&body.method.as_str()) {
+        return Err(ApiError::BadRequest(format!(
+            "invalid method '{}'; valid: {}",
+            body.method,
+            VALID_METHODS.join(", ")
+        )));
+    }
+    let payment = PaymentRepo::create(&state.db, &claims.org, &invoice_id, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "data": payment })),
+    ))
+}
+
+/// GET /api/v1/invoices/:id/payments
+pub async fn list_payments(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(invoice_id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.has("invoices:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let payments = PaymentRepo::list_by_invoice(&state.db, &claims.org, &invoice_id).await?;
+    Ok(Json(serde_json::json!({ "data": payments })))
+}

--- a/crates/api/src/handlers/reports.rs
+++ b/crates/api/src/handlers/reports.rs
@@ -1,14 +1,34 @@
 use axum::{
-    extract::{Extension, State},
+    extract::{Extension, Query, State},
     Json,
 };
 use oxidebooks_db::repos::ReportRepo;
+use serde::Deserialize;
+use time::macros::format_description;
+use time::Date;
 
 use crate::{
     error::{ApiError, ApiResult},
     middleware::Claims,
     state::AppState,
 };
+
+fn parse_date(s: &str) -> Result<Date, ApiError> {
+    let fmt = format_description!("[year]-[month]-[day]");
+    Date::parse(s, fmt)
+        .map_err(|_| ApiError::BadRequest(format!("invalid date '{s}'; expected YYYY-MM-DD")))
+}
+
+#[derive(Deserialize)]
+pub struct DateRangeQuery {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Deserialize)]
+pub struct AsOfQuery {
+    pub as_of: String,
+}
 
 /// GET /api/v1/reports/trial-balance
 ///
@@ -30,4 +50,38 @@ pub async fn trial_balance(
             "is_balanced": tb.is_balanced(),
         }
     })))
+}
+
+/// GET /api/v1/reports/profit-loss?from=YYYY-MM-DD&to=YYYY-MM-DD
+pub async fn profit_loss(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<DateRangeQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.has("reports:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let from = parse_date(&q.from)?;
+    let to = parse_date(&q.to)?;
+    if from > to {
+        return Err(ApiError::BadRequest(
+            "'from' must be on or before 'to'".into(),
+        ));
+    }
+    let report = ReportRepo::profit_loss(&state.db, &claims.org, from, to).await?;
+    Ok(Json(serde_json::json!({ "data": report })))
+}
+
+/// GET /api/v1/reports/balance-sheet?as_of=YYYY-MM-DD
+pub async fn balance_sheet(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<AsOfQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.has("reports:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let as_of = parse_date(&q.as_of)?;
+    let report = ReportRepo::balance_sheet(&state.db, &claims.org, as_of).await?;
+    Ok(Json(serde_json::json!({ "data": report })))
 }

--- a/crates/api/src/handlers/transactions.rs
+++ b/crates/api/src/handlers/transactions.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use oxidebooks_core::models::CreateJournalEntry;
 use oxidebooks_core::pagination::PageParams;
-use oxidebooks_db::repos::TransactionRepo;
+use oxidebooks_db::repos::{AuditRepo, TransactionRepo};
 use serde::Deserialize;
 use tracing::info;
 
@@ -54,6 +54,16 @@ pub async fn create_transaction(
         return Err(ApiError::Forbidden);
     }
     let entry = TransactionRepo::create(&state.db, &claims.org, &claims.sub, body).await?;
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "create",
+        "journal_entry",
+        &entry.id,
+        None,
+    )
+    .await;
     Ok((
         StatusCode::CREATED,
         Json(serde_json::json!({ "data": entry })),
@@ -81,10 +91,16 @@ pub async fn void_transaction(
         ));
     }
     let entry = TransactionRepo::void(&state.db, &claims.org, &id).await?;
-    info!(
-        entry_id = %id,
-        org_id = %claims.org,
-        "💸 journal entry voided"
-    );
+    info!(entry_id = %id, org_id = %claims.org, "journal entry voided");
+    let _ = AuditRepo::record(
+        &state.db,
+        &claims.org,
+        Some(&claims.sub),
+        "void",
+        "journal_entry",
+        &id,
+        None,
+    )
+    .await;
     Ok(Json(serde_json::json!({ "data": entry })))
 }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -15,8 +15,8 @@ use tower_http::{
 
 use crate::{
     handlers::{
-        accounts, auth, auth_sso, contacts, exchange_rates, health, identity, invoices,
-        organizations, reports, roles, scim, transactions, users,
+        accounts, audit, auth, auth_sso, contacts, exchange_rates, health, identity, invoices,
+        organizations, payments, reports, roles, scim, transactions, users,
     },
     middleware::require_auth,
     state::AppState,
@@ -151,6 +151,10 @@ pub fn build(state: AppState) -> Router {
             "/invoices/:id",
             get(invoices::get_invoice).patch(invoices::update_invoice),
         )
+        .route(
+            "/invoices/:id/payments",
+            post(payments::create_payment).get(payments::list_payments),
+        )
         // Organization settings
         .route(
             "/organizations/me",
@@ -166,6 +170,10 @@ pub fn build(state: AppState) -> Router {
         )
         // Reports
         .route("/reports/trial-balance", get(reports::trial_balance))
+        .route("/reports/profit-loss", get(reports::profit_loss))
+        .route("/reports/balance-sheet", get(reports::balance_sheet))
+        // Audit log
+        .route("/audit-log", get(audit::list_audit_log))
         // RBAC: permissions & roles
         .route("/permissions", get(roles::list_permissions))
         .route("/roles", get(roles::list_roles).post(roles::create_role))

--- a/crates/core/src/models/invoice.rs
+++ b/crates/core/src/models/invoice.rs
@@ -134,6 +134,16 @@ pub struct UpdateInvoice {
     pub notes: Option<String>,
 }
 
+/// Query filters for listing invoices.
+#[derive(Debug, Default, Clone)]
+pub struct InvoiceFilters {
+    pub status: Option<String>,
+    pub invoice_type: Option<String>,
+    pub contact_id: Option<String>,
+    pub from: Option<Date>,
+    pub to: Option<Date>,
+}
+
 impl InvoiceStatus {
     /// Returns the set of valid next states from the current status.
     pub fn allowed_transitions(&self) -> &'static [InvoiceStatus] {

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -3,6 +3,7 @@ pub mod contact;
 pub mod identity;
 pub mod invoice;
 pub mod organization;
+pub mod payment;
 pub mod reports;
 pub mod role;
 pub mod transaction;
@@ -14,11 +15,14 @@ pub use identity::{
     ProviderSummary, ProviderType, ScimToken,
 };
 pub use invoice::{
-    CreateInvoice, CreateInvoiceLine, Invoice, InvoiceLine, InvoiceStatus, InvoiceType,
-    UpdateInvoice,
+    CreateInvoice, CreateInvoiceLine, Invoice, InvoiceFilters, InvoiceLine, InvoiceStatus,
+    InvoiceType, UpdateInvoice,
 };
 pub use organization::{CreateOrganization, Organization, UpdateOrganization};
-pub use reports::{AccountBalance, TrialBalance};
+pub use payment::{CreatePayment, Payment, VALID_METHODS};
+pub use reports::{
+    AccountBalance, BalanceSheetReport, ProfitLossReport, ReportLine, ReportSection, TrialBalance,
+};
 pub use role::{AssignPermission, CreateRole, Permission, Role};
 pub use transaction::{
     CreateJournalEntry, CreateJournalLine, JournalEntry, JournalEntryStatus, JournalLine,

--- a/crates/core/src/models/payment.rs
+++ b/crates/core/src/models/payment.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use time::{Date, OffsetDateTime};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Payment {
+    pub id: String,
+    pub organization_id: String,
+    pub invoice_id: String,
+    pub amount: i64,
+    pub payment_date: Date,
+    pub method: String,
+    pub reference: Option<String>,
+    pub notes: Option<String>,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatePayment {
+    pub amount: i64,
+    #[serde(with = "crate::models::date_serde")]
+    pub payment_date: Date,
+    #[serde(default = "default_method")]
+    pub method: String,
+    pub reference: Option<String>,
+    pub notes: Option<String>,
+}
+
+fn default_method() -> String {
+    "bank_transfer".into()
+}
+
+pub const VALID_METHODS: &[&str] = &[
+    "bank_transfer",
+    "cash",
+    "check",
+    "credit_card",
+    "direct_debit",
+    "other",
+];

--- a/crates/core/src/models/reports.rs
+++ b/crates/core/src/models/reports.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use time::Date;
 
 use crate::{models::AccountType, money::MinorUnits};
 
@@ -45,6 +46,42 @@ impl TrialBalance {
     pub fn is_balanced(&self) -> bool {
         self.total_debits == self.total_credits
     }
+}
+
+// ── Profit & Loss ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportLine {
+    pub account_id: String,
+    pub account_code: String,
+    pub account_name: String,
+    pub amount: MinorUnits,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportSection {
+    pub accounts: Vec<ReportLine>,
+    pub total: MinorUnits,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfitLossReport {
+    pub from: Date,
+    pub to: Date,
+    pub revenue: ReportSection,
+    pub expenses: ReportSection,
+    pub net_income: MinorUnits,
+}
+
+// ── Balance Sheet ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BalanceSheetReport {
+    pub as_of: Date,
+    pub assets: ReportSection,
+    pub liabilities: ReportSection,
+    pub equity: ReportSection,
+    pub is_balanced: bool,
 }
 
 #[cfg(test)]

--- a/crates/db/migrations/0008_payments.sql
+++ b/crates/db/migrations/0008_payments.sql
@@ -1,0 +1,13 @@
+CREATE TABLE payments (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    invoice_id      UUID        NOT NULL REFERENCES invoices(id) ON DELETE CASCADE,
+    amount          BIGINT      NOT NULL CHECK (amount > 0),
+    payment_date    DATE        NOT NULL,
+    method          TEXT        NOT NULL DEFAULT 'bank_transfer',
+    reference       TEXT,
+    notes           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_payments_invoice ON payments (organization_id, invoice_id);

--- a/crates/db/migrations/0009_audit_events.sql
+++ b/crates/db/migrations/0009_audit_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE audit_events (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id         UUID        REFERENCES users(id) ON DELETE SET NULL,
+    action          TEXT        NOT NULL,   -- 'create' | 'update' | 'delete'
+    resource_type   TEXT        NOT NULL,   -- 'invoice' | 'transaction' | 'contact' | ...
+    resource_id     TEXT        NOT NULL,
+    changes         JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_org_time     ON audit_events (organization_id, created_at DESC);
+CREATE INDEX idx_audit_resource     ON audit_events (organization_id, resource_type, resource_id);

--- a/crates/db/src/repos/audit.rs
+++ b/crates/db/src/repos/audit.rs
@@ -1,0 +1,160 @@
+use oxidebooks_core::pagination::{encode_cursor, PageParams};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::error::{map_sqlx_err, DbError};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEvent {
+    pub id: String,
+    pub organization_id: String,
+    pub user_id: Option<String>,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: String,
+    pub changes: Option<serde_json::Value>,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(sqlx::FromRow)]
+struct AuditRow {
+    id: Uuid,
+    organization_id: Uuid,
+    user_id: Option<Uuid>,
+    action: String,
+    resource_type: String,
+    resource_id: String,
+    changes: Option<serde_json::Value>,
+    created_at: OffsetDateTime,
+}
+
+impl From<AuditRow> for AuditEvent {
+    fn from(r: AuditRow) -> Self {
+        AuditEvent {
+            id: r.id.to_string(),
+            organization_id: r.organization_id.to_string(),
+            user_id: r.user_id.map(|u| u.to_string()),
+            action: r.action,
+            resource_type: r.resource_type,
+            resource_id: r.resource_id,
+            changes: r.changes,
+            created_at: r.created_at,
+        }
+    }
+}
+
+pub struct AuditRepo;
+
+impl AuditRepo {
+    /// Record an audit event. Errors are intentionally ignored at the call site
+    /// so that audit failures do not affect the primary operation.
+    pub async fn record(
+        pool: &PgPool,
+        org_id: &str,
+        user_id: Option<&str>,
+        action: &str,
+        resource_type: &str,
+        resource_id: &str,
+        changes: Option<serde_json::Value>,
+    ) -> Result<(), DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let user_uuid = user_id.map(parse_uuid).transpose()?;
+
+        sqlx::query(
+            "INSERT INTO audit_events \
+             (organization_id, user_id, action, resource_type, resource_id, changes) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(org_uuid)
+        .bind(user_uuid)
+        .bind(action)
+        .bind(resource_type)
+        .bind(resource_id)
+        .bind(changes)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(())
+    }
+
+    pub async fn list(
+        pool: &PgPool,
+        org_id: &str,
+        resource_type: Option<&str>,
+        resource_id: Option<&str>,
+        page: &PageParams,
+    ) -> Result<(Vec<AuditEvent>, Option<String>), DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let limit = page.limit_clamped();
+        let cursor = page.decode_cursor();
+
+        // Build query with optional filters using a common approach.
+        let rows: Vec<AuditRow> = if let Some(c) = cursor {
+            let cursor_ts = time::OffsetDateTime::parse(
+                &c.created_at,
+                &time::format_description::well_known::Rfc3339,
+            )
+            .map_err(|_| DbError::Conflict("invalid cursor".into()))?;
+            let cursor_id = parse_uuid(&c.id)?;
+
+            sqlx::query_as(
+                "SELECT id, organization_id, user_id, action, resource_type, resource_id, \
+                 changes, created_at FROM audit_events \
+                 WHERE organization_id = $1 \
+                   AND ($2::text IS NULL OR resource_type = $2) \
+                   AND ($3::text IS NULL OR resource_id = $3) \
+                   AND (created_at, id) < ($4, $5) \
+                 ORDER BY created_at DESC, id DESC LIMIT $6",
+            )
+            .bind(org_uuid)
+            .bind(resource_type)
+            .bind(resource_id)
+            .bind(cursor_ts)
+            .bind(cursor_id)
+            .bind(limit + 1)
+            .fetch_all(pool)
+            .await
+            .map_err(map_sqlx_err)?
+        } else {
+            sqlx::query_as(
+                "SELECT id, organization_id, user_id, action, resource_type, resource_id, \
+                 changes, created_at FROM audit_events \
+                 WHERE organization_id = $1 \
+                   AND ($2::text IS NULL OR resource_type = $2) \
+                   AND ($3::text IS NULL OR resource_id = $3) \
+                 ORDER BY created_at DESC, id DESC LIMIT $4",
+            )
+            .bind(org_uuid)
+            .bind(resource_type)
+            .bind(resource_id)
+            .bind(limit + 1)
+            .fetch_all(pool)
+            .await
+            .map_err(map_sqlx_err)?
+        };
+
+        let has_next = rows.len() as i64 > limit;
+        let mut rows = rows;
+        if has_next {
+            rows.pop();
+        }
+        let next_cursor = if has_next {
+            rows.last()
+                .map(|r| encode_cursor(r.created_at, &r.id.to_string()))
+        } else {
+            None
+        };
+
+        Ok((
+            rows.into_iter().map(AuditEvent::from).collect(),
+            next_cursor,
+        ))
+    }
+}
+
+fn parse_uuid(s: &str) -> Result<Uuid, DbError> {
+    Uuid::parse_str(s).map_err(|_| DbError::Conflict(format!("invalid UUID: {s}")))
+}

--- a/crates/db/src/repos/invoices.rs
+++ b/crates/db/src/repos/invoices.rs
@@ -1,5 +1,5 @@
 use oxidebooks_core::models::{
-    CreateInvoice, Invoice, InvoiceLine, InvoiceStatus, InvoiceType, UpdateInvoice,
+    CreateInvoice, Invoice, InvoiceFilters, InvoiceLine, InvoiceStatus, InvoiceType, UpdateInvoice,
 };
 use oxidebooks_core::pagination::{encode_cursor, PageParams};
 use sqlx::PgPool;
@@ -45,10 +45,13 @@ impl InvoiceRepo {
         pool: &PgPool,
         org_id: &str,
         page: &PageParams,
+        filters: &InvoiceFilters,
     ) -> Result<(Vec<Invoice>, Option<String>), DbError> {
         let org_uuid = parse_uuid(org_id)?;
         let limit = page.limit_clamped();
         let cursor = page.decode_cursor();
+
+        let contact_uuid = filters.contact_id.as_deref().map(parse_uuid).transpose()?;
 
         let rows: Vec<InvoiceRow> = if let Some(c) = cursor {
             let cursor_ts = time::OffsetDateTime::parse(
@@ -61,12 +64,23 @@ impl InvoiceRepo {
                 "SELECT id, organization_id, invoice_number, contact_id, invoice_type, status, \
                  date, due_date, currency, notes, journal_entry_id, created_at, updated_at \
                  FROM invoices \
-                 WHERE organization_id = $1 AND (created_at, id) > ($2, $3) \
-                 ORDER BY created_at ASC, id ASC LIMIT $4",
+                 WHERE organization_id = $1 \
+                   AND (created_at, id) > ($2, $3) \
+                   AND ($4::text IS NULL OR status = $4) \
+                   AND ($5::text IS NULL OR invoice_type = $5) \
+                   AND ($6::uuid IS NULL OR contact_id = $6) \
+                   AND ($7::date IS NULL OR date >= $7) \
+                   AND ($8::date IS NULL OR date <= $8) \
+                 ORDER BY created_at ASC, id ASC LIMIT $9",
             )
             .bind(org_uuid)
             .bind(cursor_ts)
             .bind(cursor_id)
+            .bind(filters.status.as_deref())
+            .bind(filters.invoice_type.as_deref())
+            .bind(contact_uuid)
+            .bind(filters.from)
+            .bind(filters.to)
             .bind(limit + 1)
             .fetch_all(pool)
             .await
@@ -75,10 +89,21 @@ impl InvoiceRepo {
             sqlx::query_as(
                 "SELECT id, organization_id, invoice_number, contact_id, invoice_type, status, \
                  date, due_date, currency, notes, journal_entry_id, created_at, updated_at \
-                 FROM invoices WHERE organization_id = $1 \
-                 ORDER BY created_at ASC, id ASC LIMIT $2",
+                 FROM invoices \
+                 WHERE organization_id = $1 \
+                   AND ($2::text IS NULL OR status = $2) \
+                   AND ($3::text IS NULL OR invoice_type = $3) \
+                   AND ($4::uuid IS NULL OR contact_id = $4) \
+                   AND ($5::date IS NULL OR date >= $5) \
+                   AND ($6::date IS NULL OR date <= $6) \
+                 ORDER BY created_at ASC, id ASC LIMIT $7",
             )
             .bind(org_uuid)
+            .bind(filters.status.as_deref())
+            .bind(filters.invoice_type.as_deref())
+            .bind(contact_uuid)
+            .bind(filters.from)
+            .bind(filters.to)
             .bind(limit + 1)
             .fetch_all(pool)
             .await

--- a/crates/db/src/repos/mod.rs
+++ b/crates/db/src/repos/mod.rs
@@ -1,9 +1,11 @@
 pub mod accounts;
+pub mod audit;
 pub mod contacts;
 pub mod exchange_rates;
 pub mod identity;
 pub mod invoices;
 pub mod organizations;
+pub mod payments;
 pub mod permissions;
 pub mod reports;
 pub mod roles;
@@ -11,11 +13,13 @@ pub mod transactions;
 pub mod users;
 
 pub use accounts::AccountRepo;
+pub use audit::{AuditEvent, AuditRepo};
 pub use contacts::ContactRepo;
 pub use exchange_rates::ExchangeRateRepo;
 pub use identity::{IdentityProviderRepo, ScimTokenRepo};
 pub use invoices::InvoiceRepo;
 pub use organizations::OrganizationRepo;
+pub use payments::PaymentRepo;
 pub use permissions::PermissionRepo;
 pub use reports::ReportRepo;
 pub use roles::{RoleRepo, ROLE_ACCOUNTANT_ID, ROLE_ADMIN_ID, ROLE_OWNER_ID, ROLE_VIEWER_ID};

--- a/crates/db/src/repos/payments.rs
+++ b/crates/db/src/repos/payments.rs
@@ -1,0 +1,172 @@
+use oxidebooks_core::models::{CreatePayment, Payment};
+use sqlx::PgPool;
+use time::{Date, OffsetDateTime};
+use uuid::Uuid;
+
+use crate::error::{map_sqlx_err, DbError};
+
+#[derive(sqlx::FromRow)]
+struct PaymentRow {
+    id: Uuid,
+    organization_id: Uuid,
+    invoice_id: Uuid,
+    amount: i64,
+    payment_date: Date,
+    method: String,
+    reference: Option<String>,
+    notes: Option<String>,
+    created_at: OffsetDateTime,
+}
+
+impl From<PaymentRow> for Payment {
+    fn from(r: PaymentRow) -> Self {
+        Payment {
+            id: r.id.to_string(),
+            organization_id: r.organization_id.to_string(),
+            invoice_id: r.invoice_id.to_string(),
+            amount: r.amount,
+            payment_date: r.payment_date,
+            method: r.method,
+            reference: r.reference,
+            notes: r.notes,
+            created_at: r.created_at,
+        }
+    }
+}
+
+pub struct PaymentRepo;
+
+impl PaymentRepo {
+    /// Record a payment against an invoice and auto-update its status.
+    pub async fn create(
+        pool: &PgPool,
+        org_id: &str,
+        invoice_id: &str,
+        input: CreatePayment,
+    ) -> Result<Payment, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let inv_uuid = parse_uuid(invoice_id)?;
+        let id = Uuid::new_v4();
+
+        // Verify the invoice belongs to this org.
+        let exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM invoices WHERE organization_id = $1 AND id = $2")
+                .bind(org_uuid)
+                .bind(inv_uuid)
+                .fetch_optional(pool)
+                .await
+                .map_err(map_sqlx_err)?;
+
+        if exists.is_none() {
+            return Err(DbError::NotFound);
+        }
+
+        sqlx::query(
+            "INSERT INTO payments \
+             (id, organization_id, invoice_id, amount, payment_date, method, reference, notes) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(id)
+        .bind(org_uuid)
+        .bind(inv_uuid)
+        .bind(input.amount)
+        .bind(input.payment_date)
+        .bind(&input.method)
+        .bind(&input.reference)
+        .bind(&input.notes)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        // Compute total paid and invoice total, update status.
+        Self::sync_invoice_status(pool, org_uuid, inv_uuid).await?;
+
+        let row: PaymentRow = sqlx::query_as(
+            "SELECT id, organization_id, invoice_id, amount, payment_date, method, \
+             reference, notes, created_at FROM payments WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(row.into())
+    }
+
+    pub async fn list_by_invoice(
+        pool: &PgPool,
+        org_id: &str,
+        invoice_id: &str,
+    ) -> Result<Vec<Payment>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let inv_uuid = parse_uuid(invoice_id)?;
+
+        let rows: Vec<PaymentRow> = sqlx::query_as(
+            "SELECT id, organization_id, invoice_id, amount, payment_date, method, \
+             reference, notes, created_at \
+             FROM payments WHERE organization_id = $1 AND invoice_id = $2 \
+             ORDER BY payment_date ASC, created_at ASC",
+        )
+        .bind(org_uuid)
+        .bind(inv_uuid)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(rows.into_iter().map(Payment::from).collect())
+    }
+
+    /// Recompute invoice status based on total payments vs. invoice line total.
+    async fn sync_invoice_status(
+        pool: &PgPool,
+        org_uuid: Uuid,
+        inv_uuid: Uuid,
+    ) -> Result<(), DbError> {
+        // Invoice total = sum of quantity * unit_price * (1 + tax_rate/1_000_000)
+        // tax_rate is stored as basis points of a basis point, i.e. 1% = 10000.
+        // Simplified: total_minor_units = sum(quantity * unit_price + quantity * unit_price * tax_rate / 1_000_000)
+        let invoice_total: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(quantity * unit_price + quantity * unit_price * tax_rate / 1000000), 0)::BIGINT \
+             FROM invoice_lines WHERE invoice_id = $1",
+        )
+        .bind(inv_uuid)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let paid_total: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(amount), 0)::BIGINT FROM payments \
+             WHERE organization_id = $1 AND invoice_id = $2",
+        )
+        .bind(org_uuid)
+        .bind(inv_uuid)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let new_status = if paid_total.0 >= invoice_total.0 {
+            "paid"
+        } else if paid_total.0 > 0 {
+            "partial"
+        } else {
+            return Ok(());
+        };
+
+        sqlx::query(
+            "UPDATE invoices SET status = $1, updated_at = NOW() \
+             WHERE organization_id = $2 AND id = $3 AND status NOT IN ('voided', 'paid')",
+        )
+        .bind(new_status)
+        .bind(org_uuid)
+        .bind(inv_uuid)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(())
+    }
+}
+
+fn parse_uuid(s: &str) -> Result<Uuid, DbError> {
+    Uuid::parse_str(s).map_err(|_| DbError::Conflict(format!("invalid UUID: {s}")))
+}

--- a/crates/db/src/repos/reports.rs
+++ b/crates/db/src/repos/reports.rs
@@ -1,6 +1,10 @@
-use oxidebooks_core::models::{AccountBalance, AccountType, TrialBalance};
+use oxidebooks_core::models::{
+    AccountBalance, AccountType, BalanceSheetReport, ProfitLossReport, ReportLine, ReportSection,
+    TrialBalance,
+};
 use sqlx::PgPool;
 use std::str::FromStr;
+use time::Date;
 use uuid::Uuid;
 
 use crate::error::{map_sqlx_err, DbError};
@@ -73,6 +77,183 @@ impl ReportRepo {
             accounts,
             total_debits,
             total_credits,
+        })
+    }
+
+    /// Profit & Loss (Income Statement) for a date range.
+    pub async fn profit_loss(
+        pool: &PgPool,
+        org_id: &str,
+        from: Date,
+        to: Date,
+    ) -> Result<ProfitLossReport, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            account_id: Uuid,
+            account_code: String,
+            account_name: String,
+            account_type: String,
+            total_debit: i64,
+            total_credit: i64,
+        }
+
+        let rows: Vec<Row> = sqlx::query_as(
+            r#"
+            SELECT
+                a.id          AS account_id,
+                a.code        AS account_code,
+                a.name        AS account_name,
+                a.account_type,
+                COALESCE(SUM(jl.debit),  0)::BIGINT AS total_debit,
+                COALESCE(SUM(jl.credit), 0)::BIGINT AS total_credit
+            FROM accounts a
+            LEFT JOIN journal_lines jl ON jl.account_id = a.id
+            LEFT JOIN journal_entries je
+                ON  je.id              = jl.journal_entry_id
+                AND je.organization_id = $1
+                AND je.status          = 'posted'
+                AND je.date BETWEEN $2 AND $3
+            WHERE a.organization_id = $1
+              AND a.account_type IN ('revenue', 'expense')
+            GROUP BY a.id, a.code, a.name, a.account_type
+            ORDER BY a.code
+            "#,
+        )
+        .bind(org_uuid)
+        .bind(from)
+        .bind(to)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let mut revenue_lines = vec![];
+        let mut expense_lines = vec![];
+
+        for r in rows {
+            let amount = match r.account_type.as_str() {
+                "revenue" => r.total_credit - r.total_debit,
+                _ => r.total_debit - r.total_credit,
+            };
+            let line = ReportLine {
+                account_id: r.account_id.to_string(),
+                account_code: r.account_code,
+                account_name: r.account_name,
+                amount,
+            };
+            if r.account_type == "revenue" {
+                revenue_lines.push(line);
+            } else {
+                expense_lines.push(line);
+            }
+        }
+
+        let revenue_total: i64 = revenue_lines.iter().map(|l| l.amount).sum();
+        let expense_total: i64 = expense_lines.iter().map(|l| l.amount).sum();
+
+        Ok(ProfitLossReport {
+            from,
+            to,
+            revenue: ReportSection {
+                accounts: revenue_lines,
+                total: revenue_total,
+            },
+            expenses: ReportSection {
+                accounts: expense_lines,
+                total: expense_total,
+            },
+            net_income: revenue_total - expense_total,
+        })
+    }
+
+    /// Balance Sheet as of a specific date (cumulative from inception).
+    pub async fn balance_sheet(
+        pool: &PgPool,
+        org_id: &str,
+        as_of: Date,
+    ) -> Result<BalanceSheetReport, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            account_id: Uuid,
+            account_code: String,
+            account_name: String,
+            account_type: String,
+            total_debit: i64,
+            total_credit: i64,
+        }
+
+        let rows: Vec<Row> = sqlx::query_as(
+            r#"
+            SELECT
+                a.id          AS account_id,
+                a.code        AS account_code,
+                a.name        AS account_name,
+                a.account_type,
+                COALESCE(SUM(jl.debit),  0)::BIGINT AS total_debit,
+                COALESCE(SUM(jl.credit), 0)::BIGINT AS total_credit
+            FROM accounts a
+            LEFT JOIN journal_lines jl ON jl.account_id = a.id
+            LEFT JOIN journal_entries je
+                ON  je.id              = jl.journal_entry_id
+                AND je.organization_id = $1
+                AND je.status          = 'posted'
+                AND je.date            <= $2
+            WHERE a.organization_id = $1
+              AND a.account_type IN ('asset', 'liability', 'equity')
+            GROUP BY a.id, a.code, a.name, a.account_type
+            ORDER BY a.code
+            "#,
+        )
+        .bind(org_uuid)
+        .bind(as_of)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let mut asset_lines = vec![];
+        let mut liability_lines = vec![];
+        let mut equity_lines = vec![];
+
+        for r in rows {
+            let amount = match r.account_type.as_str() {
+                "asset" => r.total_debit - r.total_credit,
+                _ => r.total_credit - r.total_debit,
+            };
+            let line = ReportLine {
+                account_id: r.account_id.to_string(),
+                account_code: r.account_code,
+                account_name: r.account_name,
+                amount,
+            };
+            match r.account_type.as_str() {
+                "asset" => asset_lines.push(line),
+                "liability" => liability_lines.push(line),
+                _ => equity_lines.push(line),
+            }
+        }
+
+        let asset_total: i64 = asset_lines.iter().map(|l| l.amount).sum();
+        let liability_total: i64 = liability_lines.iter().map(|l| l.amount).sum();
+        let equity_total: i64 = equity_lines.iter().map(|l| l.amount).sum();
+
+        Ok(BalanceSheetReport {
+            as_of,
+            assets: ReportSection {
+                accounts: asset_lines,
+                total: asset_total,
+            },
+            liabilities: ReportSection {
+                accounts: liability_lines,
+                total: liability_total,
+            },
+            equity: ReportSection {
+                accounts: equity_lines,
+                total: equity_total,
+            },
+            is_balanced: asset_total == liability_total + equity_total,
         })
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Payments** (`POST/GET /invoices/:id/payments`): record payments against invoices; auto-transitions invoice status to `partial` or `paid` based on total collected vs invoice total
- **P&L report** (`GET /reports/profit-loss?from=&to=`): revenue vs expenses over a date range, net income
- **Balance sheet** (`GET /reports/balance-sheet?as_of=`): assets / liabilities / equity as of any date, balanced check
- **Audit log** (`GET /audit-log`): cursor-paginated event log; fire-and-forget `AuditRepo::record` wired into create/update/void/delete on transactions, invoices, and contacts
- **Invoice list filters**: `status`, `type`, `contact_id`, `from`, `to` query params
- **Migrations**: `0008_payments.sql`, `0009_audit_events.sql`
- Fixed `ReportRepo` impl block — `profit_loss` and `balance_sheet` were accidentally placed outside the impl block

Closes #21, #22, #23, #24, #25

## Test plan

- [ ] `cargo check` — passes clean
- [ ] `cargo test --package oxidebooks-core` — 75 tests pass
- [ ] `cargo fmt --check` — clean
- [ ] `POST /invoices/:id/payments` returns 201 and transitions invoice status
- [ ] `GET /reports/profit-loss?from=2026-01-01&to=2026-03-31` returns revenue/expense breakdown
- [ ] `GET /reports/balance-sheet?as_of=2026-03-31` returns assets == liabilities + equity
- [ ] `GET /audit-log` returns events with cursor pagination
- [ ] `GET /invoices?status=draft&type=invoice` filters correctly

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_