### PR TITLE
Sprint 63: payslip publish, bulk time entry approval, contact credit status

### DIFF
--- a/crates/api/src/handlers/contacts.rs
+++ b/crates/api/src/handlers/contacts.rs
@@ -153,3 +153,16 @@ pub async fn merge_contact(
     let contact = ContactRepo::merge(&state.db, &claims.org, &keep_id, &body.discard_id).await?;
     Ok(Json(serde_json::json!({ "data": contact })))
 }
+
+/// GET /api/v1/contacts/:id/credit-status
+pub async fn contact_credit_status(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let status = ContactRepo::credit_status(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": status })))
+}

--- a/crates/api/src/handlers/payslips.rs
+++ b/crates/api/src/handlers/payslips.rs
@@ -54,3 +54,29 @@ pub async fn get_payslip(
     let payslip = PayslipRepo::get_by_id(&state.db, &claims.org, &id).await?;
     Ok(Json(serde_json::json!({ "data": payslip })))
 }
+
+/// POST /api/v1/payslips/:id/publish
+pub async fn publish_payslip(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_admin() {
+        return Err(ApiError::Forbidden);
+    }
+    let payslip = PayslipRepo::publish(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": payslip })))
+}
+
+/// GET /api/v1/employees/:id/payslips
+pub async fn list_employee_payslips(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(employee_id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let payslips = PayslipRepo::list_by_employee(&state.db, &claims.org, &employee_id).await?;
+    Ok(Json(serde_json::json!({ "data": payslips })))
+}

--- a/crates/api/src/handlers/time_entries.rs
+++ b/crates/api/src/handlers/time_entries.rs
@@ -3,7 +3,10 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use oxidebooks_core::models::{BillTimeEntries, CreateTimeEntry, RejectTimeEntry, UpdateTimeEntry};
+use oxidebooks_core::models::{
+    BillTimeEntries, BulkApproveTimeEntries, BulkRejectTimeEntries, CreateTimeEntry,
+    RejectTimeEntry, UpdateTimeEntry,
+};
 use oxidebooks_db::repos::TimeEntryRepo;
 use serde::Deserialize;
 use time::format_description::well_known::Iso8601;
@@ -138,6 +141,30 @@ pub async fn reject_time_entry(
     }
     let entry = TimeEntryRepo::reject(&state.db, &claims.org, &id, body).await?;
     Ok(Json(serde_json::json!({ "data": entry })))
+}
+
+pub async fn bulk_approve_time_entries(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Json(body): Json<BulkApproveTimeEntries>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let entries = TimeEntryRepo::bulk_approve(&state.db, &claims.org, body, &claims.sub).await?;
+    Ok(Json(serde_json::json!({ "data": entries })))
+}
+
+pub async fn bulk_reject_time_entries(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Json(body): Json<BulkRejectTimeEntries>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let entries = TimeEntryRepo::bulk_reject(&state.db, &claims.org, body).await?;
+    Ok(Json(serde_json::json!({ "data": entries })))
 }
 
 pub async fn bill_time_entries(

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -743,6 +743,14 @@ pub fn build(state: AppState) -> Router {
         .route("/time-entries/bill", post(time_entries::bill_time_entries))
         .route("/time-entries/summary", get(time_entries::time_summary))
         .route(
+            "/time-entries/bulk-approve",
+            post(time_entries::bulk_approve_time_entries),
+        )
+        .route(
+            "/time-entries/bulk-reject",
+            post(time_entries::bulk_reject_time_entries),
+        )
+        .route(
             "/time-entries/:id/approve",
             post(time_entries::approve_time_entry),
         )
@@ -1078,6 +1086,10 @@ pub fn build(state: AppState) -> Router {
         // Contacts statement
         .route("/contacts/:id/statement", get(contacts::contact_statement))
         .route("/contacts/:id/merge", post(contacts::merge_contact))
+        .route(
+            "/contacts/:id/credit-status",
+            get(contacts::contact_credit_status),
+        )
         // Expense policies
         .route(
             "/expense-policies",
@@ -1300,6 +1312,11 @@ pub fn build(state: AppState) -> Router {
             post(payslips::create_payslip).get(payslips::list_payslips),
         )
         .route("/payslips/:id", get(payslips::get_payslip))
+        .route("/payslips/:id/publish", post(payslips::publish_payslip))
+        .route(
+            "/employees/:id/payslips",
+            get(payslips::list_employee_payslips),
+        )
         // Leave management
         .route(
             "/leave-types",

--- a/crates/core/src/models/contact.rs
+++ b/crates/core/src/models/contact.rs
@@ -68,6 +68,16 @@ pub struct UpdateContact {
     pub is_1099_vendor: Option<bool>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactCreditStatus {
+    pub contact_id: String,
+    pub credit_limit: Option<i64>,
+    pub credit_limit_behaviour: String,
+    pub outstanding_balance: i64,
+    pub available_credit: Option<i64>,
+    pub overlimit: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -133,7 +133,7 @@ pub use closed_period::{ClosedPeriod, CreateClosedPeriod};
 pub use commission::{CreateSalesCommission, PayCommission, SalesCommission};
 pub use consolidated::{ConsolidatedProfitLoss, OrgProfitLoss};
 pub use consolidation_elimination::{ConsolidationElimination, CreateConsolidationElimination};
-pub use contact::{Contact, ContactType, CreateContact, UpdateContact};
+pub use contact::{Contact, ContactCreditStatus, ContactType, CreateContact, UpdateContact};
 pub use contact_group::{ContactGroup, CreateContactGroup, UpdateContactGroup};
 pub use contractor_tax_info::{
     Contractor1099Summary, ContractorTaxInfo, CreateContractorTaxInfo, UpdateContractorTaxInfo,
@@ -309,7 +309,8 @@ pub use tax_period::{CreateTaxPeriod, FileTaxPeriod, TaxPeriod};
 pub use tax_rate::{CreateTaxRate, TaxRate, UpdateTaxRate};
 pub use tax_rule::{CreateTaxRule, SuggestedTaxRate, TaxRule, UpdateTaxRule};
 pub use time_entry::{
-    BillTimeEntries, CreateTimeEntry, RejectTimeEntry, TimeEntry, TimeSummaryRow, UpdateTimeEntry,
+    BillTimeEntries, BulkApproveTimeEntries, BulkRejectTimeEntries, CreateTimeEntry,
+    RejectTimeEntry, TimeEntry, TimeSummaryRow, UpdateTimeEntry,
 };
 pub use tracking_category::{
     CreateTrackingCategory, CreateTrackingOption, TrackingCategory, TrackingOption,

--- a/crates/core/src/models/payslip.rs
+++ b/crates/core/src/models/payslip.rs
@@ -14,6 +14,13 @@ pub struct Payslip {
     pub deductions: MinorUnits,
     pub net_pay: MinorUnits,
     pub notes: Option<String>,
+    pub status: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub published_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 }

--- a/crates/core/src/models/time_entry.rs
+++ b/crates/core/src/models/time_entry.rs
@@ -81,3 +81,14 @@ pub struct TimeSummaryRow {
 pub struct RejectTimeEntry {
     pub reason: Option<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkApproveTimeEntries {
+    pub entry_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BulkRejectTimeEntries {
+    pub entry_ids: Vec<String>,
+    pub reason: Option<String>,
+}

--- a/crates/db/migrations/0128_payslip_status.sql
+++ b/crates/db/migrations/0128_payslip_status.sql
@@ -1,0 +1,4 @@
+ALTER TABLE payslips
+    ADD COLUMN status       TEXT        NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'published')),
+    ADD COLUMN published_at TIMESTAMPTZ;

--- a/crates/db/src/repos/contacts.rs
+++ b/crates/db/src/repos/contacts.rs
@@ -1,4 +1,6 @@
-use oxidebooks_core::models::{Contact, ContactType, CreateContact, UpdateContact};
+use oxidebooks_core::models::{
+    Contact, ContactCreditStatus, ContactType, CreateContact, UpdateContact,
+};
 use oxidebooks_core::pagination::{encode_cursor, PageParams};
 use sqlx::PgPool;
 use time::OffsetDateTime;
@@ -317,6 +319,44 @@ impl ContactRepo {
             .map_err(map_sqlx_err)?;
 
         Self::get_by_id(pool, org_id, keep_id).await
+    }
+
+    pub async fn credit_status(
+        pool: &PgPool,
+        org_id: &str,
+        id: &str,
+    ) -> Result<ContactCreditStatus, DbError> {
+        let contact = Self::get_by_id(pool, org_id, id).await?;
+        let org_uuid = parse_uuid(org_id)?;
+        let id_uuid = parse_uuid(id)?;
+
+        let outstanding: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(total_amount - amount_paid), 0)::BIGINT \
+             FROM invoices \
+             WHERE organization_id = $1 AND contact_id = $2 \
+               AND invoice_type = 'invoice' \
+               AND status NOT IN ('draft', 'voided', 'paid')",
+        )
+        .bind(org_uuid)
+        .bind(id_uuid)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let available_credit = contact.credit_limit.map(|limit| limit - outstanding);
+        let overlimit = contact
+            .credit_limit
+            .map(|limit| outstanding > limit)
+            .unwrap_or(false);
+
+        Ok(ContactCreditStatus {
+            contact_id: id.to_string(),
+            credit_limit: contact.credit_limit,
+            credit_limit_behaviour: contact.credit_limit_behaviour,
+            outstanding_balance: outstanding,
+            available_credit,
+            overlimit,
+        })
     }
 }
 

--- a/crates/db/src/repos/payslips.rs
+++ b/crates/db/src/repos/payslips.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 
 use crate::error::{map_sqlx_err, DbError};
 
+const COLS: &str = "id, organization_id, payroll_run_id, employee_id, gross_pay, \
+                    tax_withheld, deductions, net_pay, notes, status, published_at, created_at";
+
 #[derive(sqlx::FromRow)]
 struct PayslipRow {
     id: Uuid,
@@ -16,6 +19,8 @@ struct PayslipRow {
     deductions: i64,
     net_pay: i64,
     notes: Option<String>,
+    status: String,
+    published_at: Option<OffsetDateTime>,
     created_at: OffsetDateTime,
 }
 
@@ -31,6 +36,8 @@ impl From<PayslipRow> for Payslip {
             deductions: r.deductions,
             net_pay: r.net_pay,
             notes: r.notes,
+            status: r.status,
+            published_at: r.published_at,
             created_at: r.created_at,
         }
     }
@@ -46,7 +53,6 @@ impl PayslipRepo {
     ) -> Result<Vec<Payslip>, DbError> {
         let org_uuid = parse_uuid(org_id)?;
         let run_uuid = parse_uuid(run_id)?;
-        // Verify run belongs to org.
         let exists: Option<(Uuid,)> =
             sqlx::query_as("SELECT id FROM payroll_runs WHERE organization_id = $1 AND id = $2")
                 .bind(org_uuid)
@@ -57,12 +63,30 @@ impl PayslipRepo {
         if exists.is_none() {
             return Err(DbError::NotFound);
         }
-        let rows: Vec<PayslipRow> = sqlx::query_as(
-            "SELECT id, organization_id, payroll_run_id, employee_id, gross_pay, \
-             tax_withheld, deductions, net_pay, notes, created_at \
-             FROM payslips WHERE payroll_run_id = $1 ORDER BY created_at ASC",
-        )
+        let rows: Vec<PayslipRow> = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM payslips WHERE payroll_run_id = $1 ORDER BY created_at ASC"
+        ))
         .bind(run_uuid)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+        Ok(rows.into_iter().map(Payslip::from).collect())
+    }
+
+    pub async fn list_by_employee(
+        pool: &PgPool,
+        org_id: &str,
+        employee_id: &str,
+    ) -> Result<Vec<Payslip>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let emp_uuid = parse_uuid(employee_id)?;
+        let rows: Vec<PayslipRow> = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM payslips \
+             WHERE organization_id = $1 AND employee_id = $2 \
+             ORDER BY created_at DESC"
+        ))
+        .bind(org_uuid)
+        .bind(emp_uuid)
         .fetch_all(pool)
         .await
         .map_err(map_sqlx_err)?;
@@ -72,11 +96,9 @@ impl PayslipRepo {
     pub async fn get_by_id(pool: &PgPool, org_id: &str, id: &str) -> Result<Payslip, DbError> {
         let org_uuid = parse_uuid(org_id)?;
         let id_uuid = parse_uuid(id)?;
-        let row: PayslipRow = sqlx::query_as(
-            "SELECT id, organization_id, payroll_run_id, employee_id, gross_pay, \
-             tax_withheld, deductions, net_pay, notes, created_at \
-             FROM payslips WHERE organization_id = $1 AND id = $2",
-        )
+        let row: PayslipRow = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM payslips WHERE organization_id = $1 AND id = $2"
+        ))
         .bind(org_uuid)
         .bind(id_uuid)
         .fetch_optional(pool)
@@ -96,7 +118,6 @@ impl PayslipRepo {
         let run_uuid = parse_uuid(run_id)?;
         let emp_uuid = parse_uuid(&input.employee_id)?;
 
-        // Verify run belongs to org.
         let exists: Option<(Uuid,)> =
             sqlx::query_as("SELECT id FROM payroll_runs WHERE organization_id = $1 AND id = $2")
                 .bind(org_uuid)
@@ -108,7 +129,6 @@ impl PayslipRepo {
             return Err(DbError::NotFound);
         }
 
-        // Verify employee belongs to org.
         let emp_exists: Option<(Uuid,)> =
             sqlx::query_as("SELECT id FROM employees WHERE organization_id = $1 AND id = $2")
                 .bind(org_uuid)
@@ -138,7 +158,7 @@ impl PayslipRepo {
             "INSERT INTO payslips \
              (id, organization_id, payroll_run_id, employee_id, gross_pay, \
               tax_withheld, deductions, net_pay, notes) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
         )
         .bind(id)
         .bind(org_uuid)
@@ -154,6 +174,27 @@ impl PayslipRepo {
         .map_err(map_sqlx_err)?;
 
         Self::get_by_id(pool, org_id, &id.to_string()).await
+    }
+
+    /// Transition payslip from draft → published, making it visible to the employee.
+    pub async fn publish(pool: &PgPool, org_id: &str, id: &str) -> Result<Payslip, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let id_uuid = parse_uuid(id)?;
+        let n = sqlx::query(
+            "UPDATE payslips \
+             SET status = 'published', published_at = NOW() \
+             WHERE organization_id = $1 AND id = $2 AND status = 'draft'",
+        )
+        .bind(org_uuid)
+        .bind(id_uuid)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .rows_affected();
+        if n == 0 {
+            return Err(DbError::NotFound);
+        }
+        Self::get_by_id(pool, org_id, id).await
     }
 }
 

--- a/crates/db/src/repos/time_entries.rs
+++ b/crates/db/src/repos/time_entries.rs
@@ -1,5 +1,6 @@
 use oxidebooks_core::models::{
-    BillTimeEntries, CreateTimeEntry, RejectTimeEntry, TimeEntry, TimeSummaryRow, UpdateTimeEntry,
+    BillTimeEntries, BulkApproveTimeEntries, BulkRejectTimeEntries, CreateTimeEntry,
+    RejectTimeEntry, TimeEntry, TimeSummaryRow, UpdateTimeEntry,
 };
 use sqlx::PgPool;
 use time::{Date, OffsetDateTime};
@@ -259,6 +260,82 @@ impl TimeEntryRepo {
             return Err(DbError::NotFound);
         }
         Self::get_by_id(pool, org_id, id).await
+    }
+
+    pub async fn bulk_approve(
+        pool: &PgPool,
+        org_id: &str,
+        input: BulkApproveTimeEntries,
+        approver_id: &str,
+    ) -> Result<Vec<TimeEntry>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let approver_uuid = parse_uuid(approver_id)?;
+        let ids: Vec<Uuid> = input
+            .entry_ids
+            .iter()
+            .map(|s| parse_uuid(s))
+            .collect::<Result<_, _>>()?;
+
+        sqlx::query(
+            "UPDATE time_entries \
+             SET approval_status = 'approved', approved_by = $1, approved_at = NOW(), \
+                 rejection_reason = NULL, updated_at = NOW() \
+             WHERE organization_id = $2 AND id = ANY($3) AND approval_status = 'pending'",
+        )
+        .bind(approver_uuid)
+        .bind(org_uuid)
+        .bind(&ids)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let rows: Vec<TimeEntryRow> = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM time_entries \
+             WHERE organization_id = $1 AND id = ANY($2) ORDER BY entry_date DESC"
+        ))
+        .bind(org_uuid)
+        .bind(&ids)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+        Ok(rows.into_iter().map(from_row).collect())
+    }
+
+    pub async fn bulk_reject(
+        pool: &PgPool,
+        org_id: &str,
+        input: BulkRejectTimeEntries,
+    ) -> Result<Vec<TimeEntry>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let ids: Vec<Uuid> = input
+            .entry_ids
+            .iter()
+            .map(|s| parse_uuid(s))
+            .collect::<Result<_, _>>()?;
+
+        sqlx::query(
+            "UPDATE time_entries \
+             SET approval_status = 'rejected', approved_by = NULL, approved_at = NULL, \
+                 rejection_reason = $1, updated_at = NOW() \
+             WHERE organization_id = $2 AND id = ANY($3) AND approval_status = 'pending'",
+        )
+        .bind(input.reason)
+        .bind(org_uuid)
+        .bind(&ids)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let rows: Vec<TimeEntryRow> = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM time_entries \
+             WHERE organization_id = $1 AND id = ANY($2) ORDER BY entry_date DESC"
+        ))
+        .bind(org_uuid)
+        .bind(&ids)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+        Ok(rows.into_iter().map(from_row).collect())
     }
 
     /// Convert unbilled time entries into invoice lines on an existing invoice.


### PR DESCRIPTION
## Summary

- **Payslip publish workflow**: migration 0128 adds `status` (`draft`/`published`) and `published_at` to payslips. `POST /payslips/:id/publish` (admin-only) transitions a draft payslip to published. `GET /employees/:id/payslips` lists all payslips for an employee across all payroll runs.
- **Bulk time entry approval**: `POST /time-entries/bulk-approve` approves a list of pending entries in one call (records approver). `POST /time-entries/bulk-reject` rejects a list with an optional shared reason.
- **Contact credit status**: `GET /contacts/:id/credit-status` returns `credit_limit`, `outstanding_balance` (sum of unpaid invoice balances), `available_credit`, and `overlimit` flag — useful for blocking invoices when a customer exceeds their credit limit.

## Test plan

- [ ] `cargo check` / `clippy` / `fmt` pass
- [ ] 77 core unit tests pass
- [ ] `POST /payslips/:id/publish` transitions draft → published; second call returns 404
- [ ] `GET /employees/:id/payslips` returns payslips across multiple payroll runs
- [ ] `POST /time-entries/bulk-approve` with `{ "entry_ids": [...] }` approves all pending entries
- [ ] `GET /contacts/:id/credit-status` returns correct outstanding balance and overlimit flag

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_