### PR TITLE
Fix three P1 bugs: audit 403, invoice paid-status, report double-counting

### DIFF
--- a/crates/api/src/handlers/audit.rs
+++ b/crates/api/src/handlers/audit.rs
@@ -26,7 +26,7 @@ pub async fn list_audit_log(
     Extension(claims): Extension<Claims>,
     Query(q): Query<AuditQuery>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    if !claims.has("audit:read") {
+    if !claims.is_admin() {
         return Err(ApiError::Forbidden);
     }
     let (events, next_cursor) = AuditRepo::list(

--- a/crates/db/src/repos/payments.rs
+++ b/crates/db/src/repos/payments.rs
@@ -422,7 +422,12 @@ impl PaymentRepo {
         inv_uuid: Uuid,
     ) -> Result<(), DbError> {
         let invoice_total: (i64,) = sqlx::query_as(
-            "SELECT COALESCE(SUM(quantity * unit_price + quantity * unit_price * tax_rate / 1000000), 0)::BIGINT \
+            "SELECT COALESCE(SUM(
+                 quantity * unit_price / 100
+                 - quantity * unit_price / 100 * discount_pct / 10000
+                 + (quantity * unit_price / 100 - quantity * unit_price / 100 * discount_pct / 10000)
+                   * tax_rate / 10000
+             ), 0)::BIGINT \
              FROM invoice_lines WHERE invoice_id = $1",
         )
         .bind(inv_uuid)

--- a/crates/db/src/repos/reports.rs
+++ b/crates/db/src/repos/reports.rs
@@ -54,11 +54,13 @@ impl ReportRepo {
                 COALESCE(SUM(jl.debit),  0)::BIGINT AS debit_total,
                 COALESCE(SUM(jl.credit), 0)::BIGINT AS credit_total
             FROM accounts a
-            LEFT JOIN journal_lines jl ON jl.account_id = a.id
-            LEFT JOIN journal_entries je
-                ON  je.id              = jl.journal_entry_id
-                AND je.organization_id = $1
-                AND je.status          = 'posted'
+            LEFT JOIN (
+                SELECT jl.account_id, jl.debit, jl.credit
+                FROM journal_lines jl
+                JOIN journal_entries je ON je.id = jl.journal_entry_id
+                WHERE je.organization_id = $1
+                  AND je.status = 'posted'
+            ) jl ON jl.account_id = a.id
             WHERE a.organization_id = $1
               AND a.is_active = TRUE
             GROUP BY a.id, a.code, a.name, a.account_type
@@ -124,12 +126,14 @@ impl ReportRepo {
                 COALESCE(SUM(jl.debit),  0)::BIGINT AS total_debit,
                 COALESCE(SUM(jl.credit), 0)::BIGINT AS total_credit
             FROM accounts a
-            LEFT JOIN journal_lines jl ON jl.account_id = a.id
-            LEFT JOIN journal_entries je
-                ON  je.id              = jl.journal_entry_id
-                AND je.organization_id = $1
-                AND je.status          = 'posted'
-                AND je.date BETWEEN $2 AND $3
+            LEFT JOIN (
+                SELECT jl.account_id, jl.debit, jl.credit
+                FROM journal_lines jl
+                JOIN journal_entries je ON je.id = jl.journal_entry_id
+                WHERE je.organization_id = $1
+                  AND je.status = 'posted'
+                  AND je.date BETWEEN $2 AND $3
+            ) jl ON jl.account_id = a.id
             WHERE a.organization_id = $1
               AND a.account_type IN ('revenue', 'expense')
             GROUP BY a.id, a.code, a.name, a.account_type
@@ -210,12 +214,14 @@ impl ReportRepo {
                 COALESCE(SUM(jl.debit),  0)::BIGINT AS total_debit,
                 COALESCE(SUM(jl.credit), 0)::BIGINT AS total_credit
             FROM accounts a
-            LEFT JOIN journal_lines jl ON jl.account_id = a.id
-            LEFT JOIN journal_entries je
-                ON  je.id              = jl.journal_entry_id
-                AND je.organization_id = $1
-                AND je.status          = 'posted'
-                AND je.date            <= $2
+            LEFT JOIN (
+                SELECT jl.account_id, jl.debit, jl.credit
+                FROM journal_lines jl
+                JOIN journal_entries je ON je.id = jl.journal_entry_id
+                WHERE je.organization_id = $1
+                  AND je.status = 'posted'
+                  AND je.date <= $2
+            ) jl ON jl.account_id = a.id
             WHERE a.organization_id = $1
               AND a.account_type IN ('asset', 'liability', 'equity')
             GROUP BY a.id, a.code, a.name, a.account_type


### PR DESCRIPTION
## Summary

Three P1 bugs identified by Codex review of PR #26 (code already in main).

### Bug 1 — Audit log always returns 403
`GET /audit-log` checked `claims.has("audit:read")` but `audit:read` was never inserted into the `permissions` table or assigned to any role. Every request returned 403 regardless of role.

**Fix:** replaced with `claims.is_admin()` — audit logs are admin/owner-only, consistent with other sensitive endpoints.

### Bug 2 — Invoices never reach `paid` status
`sync_invoice_status` computed `SUM(quantity * unit_price + ...)` but `invoice_lines.quantity` is stored as `qty × 100` (migration comment: `-- qty × 100`). This inflated the computed total by 100×, so normal payments only covered ~1% of the "total", leaving invoices permanently stuck at `partial`.

**Fix:** corrected formula to `quantity * unit_price / 100` (matching `InvoiceLine::gross_total()`), and also applied `discount_pct` before tax to match the domain model.

### Bug 3 — P&L, trial balance, balance sheet count draft/out-of-range entries
All three report queries used `LEFT JOIN journal_lines jl ... LEFT JOIN journal_entries je ON ... AND je.status='posted' AND je.date ...`. Because the `je` constraints are in the ON clause of a LEFT JOIN, rows where `je` is NULL (draft entries, wrong date, wrong org) still contribute `jl.debit`/`jl.credit` to the SUM.

**Fix:** restructured to `LEFT JOIN (SELECT ... FROM journal_lines JOIN journal_entries WHERE <filters>) jl ON jl.account_id = a.id` — only matching lines reach the outer SUM.

## Test plan
- [ ] `cargo check` ✅
- [ ] `cargo clippy -- -D warnings` ✅
- [ ] `cargo fmt --check` ✅
- [ ] `cargo test --package oxidebooks-core` — 77 tests pass ✅

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_