### PR TITLE
Sprint 80: Audit Trail & Compliance

### DIFF
--- a/crates/api/src/handlers/audit.rs
+++ b/crates/api/src/handlers/audit.rs
@@ -1,15 +1,18 @@
 use axum::{
     extract::{Extension, Query, State},
+    response::Response,
     Json,
 };
 use oxidebooks_core::pagination::PageParams;
 use oxidebooks_db::repos::AuditRepo;
 use serde::Deserialize;
+use time::OffsetDateTime;
 
 use crate::{
     error::{ApiError, ApiResult},
     middleware::Claims,
     state::AppState,
+    xlsx::{build_xlsx, XLSX_CONTENT_TYPE},
 };
 
 #[derive(Debug, Deserialize)]
@@ -18,9 +21,17 @@ pub struct AuditQuery {
     pub page: PageParams,
     pub resource_type: Option<String>,
     pub resource_id: Option<String>,
+    pub user_id: Option<String>,
+    pub severity: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
 }
 
-/// GET /api/v1/audit-log
+fn parse_ts(s: &str) -> Result<OffsetDateTime, ApiError> {
+    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+        .map_err(|_| ApiError::BadRequest(format!("invalid timestamp: {s}")))
+}
+
 pub async fn list_audit_log(
     State(state): State<AppState>,
     Extension(claims): Extension<Claims>,
@@ -29,11 +40,18 @@ pub async fn list_audit_log(
     if !claims.is_admin() {
         return Err(ApiError::Forbidden);
     }
+    let since = q.since.as_deref().map(parse_ts).transpose()?;
+    let until = q.until.as_deref().map(parse_ts).transpose()?;
+
     let (events, next_cursor) = AuditRepo::list(
         &state.db,
         &claims.org,
         q.resource_type.as_deref(),
         q.resource_id.as_deref(),
+        q.user_id.as_deref(),
+        q.severity.as_deref(),
+        since,
+        until,
         &q.page,
     )
     .await?;
@@ -41,4 +59,123 @@ pub async fn list_audit_log(
         "data": events,
         "pagination": { "has_next": next_cursor.is_some(), "next_cursor": next_cursor }
     })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExportQuery {
+    pub format: Option<String>,
+    pub resource_type: Option<String>,
+    pub user_id: Option<String>,
+    pub severity: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+pub async fn export_audit_log(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<ExportQuery>,
+) -> ApiResult<Response> {
+    if !claims.is_admin() {
+        return Err(ApiError::Forbidden);
+    }
+    let since = q.since.as_deref().map(parse_ts).transpose()?;
+    let until = q.until.as_deref().map(parse_ts).transpose()?;
+
+    let events = AuditRepo::list_for_export(
+        &state.db,
+        &claims.org,
+        q.resource_type.as_deref(),
+        q.user_id.as_deref(),
+        q.severity.as_deref(),
+        since,
+        until,
+    )
+    .await?;
+
+    let headers = &[
+        "ID",
+        "Timestamp",
+        "User ID",
+        "Action",
+        "Resource Type",
+        "Resource ID",
+        "Severity",
+        "IP Address",
+        "User Agent",
+    ];
+
+    let rows: Vec<Vec<String>> = events
+        .iter()
+        .map(|e| {
+            vec![
+                e.id.clone(),
+                e.created_at
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .unwrap_or_default(),
+                e.user_id.clone().unwrap_or_default(),
+                e.action.clone(),
+                e.resource_type.clone(),
+                e.resource_id.clone(),
+                e.severity.clone(),
+                e.ip_address.clone().unwrap_or_default(),
+                e.user_agent.clone().unwrap_or_default(),
+            ]
+        })
+        .collect();
+
+    match q.format.as_deref() {
+        Some("xlsx") => {
+            let bytes = build_xlsx("Audit Log", headers, &rows, &[]);
+            Ok(Response::builder()
+                .header("Content-Type", XLSX_CONTENT_TYPE)
+                .header(
+                    "Content-Disposition",
+                    "attachment; filename=\"audit-log.xlsx\"",
+                )
+                .body(axum::body::Body::from(bytes))
+                .unwrap())
+        }
+        _ => {
+            let mut csv = headers.join(",") + "\n";
+            for row in &rows {
+                let line = row
+                    .iter()
+                    .map(|v| format!("\"{}\"", v.replace('"', "\"\"")))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                csv.push_str(&line);
+                csv.push('\n');
+            }
+            Ok(Response::builder()
+                .header("Content-Type", "text/csv")
+                .header(
+                    "Content-Disposition",
+                    "attachment; filename=\"audit-log.csv\"",
+                )
+                .body(axum::body::Body::from(csv))
+                .unwrap())
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SummaryQuery {
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+pub async fn compliance_summary(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<SummaryQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_admin() {
+        return Err(ApiError::Forbidden);
+    }
+    let since = q.since.as_deref().map(parse_ts).transpose()?;
+    let until = q.until.as_deref().map(parse_ts).transpose()?;
+
+    let summary = AuditRepo::compliance_summary(&state.db, &claims.org, since, until).await?;
+    Ok(Json(serde_json::json!({ "data": summary })))
 }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -387,6 +387,11 @@ pub fn build(state: AppState) -> Router {
         .route("/search", get(reports::global_search))
         // Audit log
         .route("/audit-log", get(audit::list_audit_log))
+        .route("/audit-log/export", get(audit::export_audit_log))
+        .route(
+            "/audit-log/compliance-summary",
+            get(audit::compliance_summary),
+        )
         // Tax rates
         .route(
             "/tax-rates",

--- a/crates/db/migrations/0144_audit_enhancements.sql
+++ b/crates/db/migrations/0144_audit_enhancements.sql
@@ -1,0 +1,16 @@
+-- Audit trail enhancements: IP address, user agent, severity, user-activity index
+
+ALTER TABLE audit_events
+    ADD COLUMN IF NOT EXISTS ip_address  INET,
+    ADD COLUMN IF NOT EXISTS user_agent  TEXT,
+    ADD COLUMN IF NOT EXISTS severity    TEXT NOT NULL DEFAULT 'info'
+        CHECK (severity IN ('info', 'warning', 'critical'));
+
+-- Fast look-up of all events for a specific user
+CREATE INDEX IF NOT EXISTS idx_audit_user
+    ON audit_events (organization_id, user_id, created_at DESC);
+
+-- Fast look-up by severity
+CREATE INDEX IF NOT EXISTS idx_audit_severity
+    ON audit_events (organization_id, severity, created_at DESC)
+    WHERE severity <> 'info';

--- a/crates/db/src/repos/audit.rs
+++ b/crates/db/src/repos/audit.rs
@@ -14,7 +14,11 @@ pub struct AuditEvent {
     pub action: String,
     pub resource_type: String,
     pub resource_id: String,
+    pub severity: String,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
     pub changes: Option<serde_json::Value>,
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 }
 
@@ -26,6 +30,9 @@ struct AuditRow {
     action: String,
     resource_type: String,
     resource_id: String,
+    severity: String,
+    ip_address: Option<String>,
+    user_agent: Option<String>,
     changes: Option<serde_json::Value>,
     created_at: OffsetDateTime,
 }
@@ -39,17 +46,54 @@ impl From<AuditRow> for AuditEvent {
             action: r.action,
             resource_type: r.resource_type,
             resource_id: r.resource_id,
+            severity: r.severity,
+            ip_address: r.ip_address,
+            user_agent: r.user_agent,
             changes: r.changes,
             created_at: r.created_at,
         }
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComplianceSummaryRow {
+    pub user_id: Option<String>,
+    pub action: String,
+    pub resource_type: String,
+    pub severity: String,
+    pub event_count: i64,
+}
+
+#[derive(sqlx::FromRow)]
+struct SummaryRow {
+    user_id: Option<Uuid>,
+    action: String,
+    resource_type: String,
+    severity: String,
+    event_count: i64,
+}
+
+impl From<SummaryRow> for ComplianceSummaryRow {
+    fn from(r: SummaryRow) -> Self {
+        ComplianceSummaryRow {
+            user_id: r.user_id.map(|u| u.to_string()),
+            action: r.action,
+            resource_type: r.resource_type,
+            severity: r.severity,
+            event_count: r.event_count,
+        }
+    }
+}
+
+const COLS: &str = "id, organization_id, user_id, action, resource_type, resource_id, \
+    severity, ip_address::TEXT, user_agent, changes, created_at";
+
 pub struct AuditRepo;
 
 impl AuditRepo {
     /// Record an audit event. Errors are intentionally ignored at the call site
     /// so that audit failures do not affect the primary operation.
+    #[allow(clippy::too_many_arguments)]
     pub async fn record(
         pool: &PgPool,
         org_id: &str,
@@ -59,13 +103,42 @@ impl AuditRepo {
         resource_id: &str,
         changes: Option<serde_json::Value>,
     ) -> Result<(), DbError> {
+        Self::record_full(
+            pool,
+            org_id,
+            user_id,
+            action,
+            resource_type,
+            resource_id,
+            changes,
+            "info",
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_full(
+        pool: &PgPool,
+        org_id: &str,
+        user_id: Option<&str>,
+        action: &str,
+        resource_type: &str,
+        resource_id: &str,
+        changes: Option<serde_json::Value>,
+        severity: &str,
+        ip_address: Option<&str>,
+        user_agent: Option<&str>,
+    ) -> Result<(), DbError> {
         let org_uuid = parse_uuid(org_id)?;
         let user_uuid = user_id.map(parse_uuid).transpose()?;
 
         sqlx::query(
             "INSERT INTO audit_events \
-             (organization_id, user_id, action, resource_type, resource_id, changes) \
-             VALUES ($1, $2, $3, $4, $5, $6)",
+             (organization_id, user_id, action, resource_type, resource_id, \
+              changes, severity, ip_address, user_agent) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8::inet,$9)",
         )
         .bind(org_uuid)
         .bind(user_uuid)
@@ -73,6 +146,9 @@ impl AuditRepo {
         .bind(resource_type)
         .bind(resource_id)
         .bind(changes)
+        .bind(severity)
+        .bind(ip_address)
+        .bind(user_agent)
         .execute(pool)
         .await
         .map_err(map_sqlx_err)?;
@@ -80,18 +156,23 @@ impl AuditRepo {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list(
         pool: &PgPool,
         org_id: &str,
         resource_type: Option<&str>,
         resource_id: Option<&str>,
+        user_id: Option<&str>,
+        severity: Option<&str>,
+        since: Option<OffsetDateTime>,
+        until: Option<OffsetDateTime>,
         page: &PageParams,
     ) -> Result<(Vec<AuditEvent>, Option<String>), DbError> {
         let org_uuid = parse_uuid(org_id)?;
+        let user_uuid = user_id.map(parse_uuid).transpose()?;
         let limit = page.limit_clamped();
         let cursor = page.decode_cursor();
 
-        // Build query with optional filters using a common approach.
         let rows: Vec<AuditRow> = if let Some(c) = cursor {
             let cursor_ts = time::OffsetDateTime::parse(
                 &c.created_at,
@@ -100,18 +181,25 @@ impl AuditRepo {
             .map_err(|_| DbError::Conflict("invalid cursor".into()))?;
             let cursor_id = parse_uuid(&c.id)?;
 
-            sqlx::query_as(
-                "SELECT id, organization_id, user_id, action, resource_type, resource_id, \
-                 changes, created_at FROM audit_events \
+            sqlx::query_as(&format!(
+                "SELECT {COLS} FROM audit_events \
                  WHERE organization_id = $1 \
                    AND ($2::text IS NULL OR resource_type = $2) \
                    AND ($3::text IS NULL OR resource_id = $3) \
-                   AND (created_at, id) < ($4, $5) \
-                 ORDER BY created_at DESC, id DESC LIMIT $6",
-            )
+                   AND ($4::uuid IS NULL OR user_id = $4) \
+                   AND ($5::text IS NULL OR severity = $5) \
+                   AND ($6::timestamptz IS NULL OR created_at >= $6) \
+                   AND ($7::timestamptz IS NULL OR created_at <= $7) \
+                   AND (created_at, id) < ($8, $9) \
+                 ORDER BY created_at DESC, id DESC LIMIT $10"
+            ))
             .bind(org_uuid)
             .bind(resource_type)
             .bind(resource_id)
+            .bind(user_uuid)
+            .bind(severity)
+            .bind(since)
+            .bind(until)
             .bind(cursor_ts)
             .bind(cursor_id)
             .bind(limit + 1)
@@ -119,17 +207,24 @@ impl AuditRepo {
             .await
             .map_err(map_sqlx_err)?
         } else {
-            sqlx::query_as(
-                "SELECT id, organization_id, user_id, action, resource_type, resource_id, \
-                 changes, created_at FROM audit_events \
+            sqlx::query_as(&format!(
+                "SELECT {COLS} FROM audit_events \
                  WHERE organization_id = $1 \
                    AND ($2::text IS NULL OR resource_type = $2) \
                    AND ($3::text IS NULL OR resource_id = $3) \
-                 ORDER BY created_at DESC, id DESC LIMIT $4",
-            )
+                   AND ($4::uuid IS NULL OR user_id = $4) \
+                   AND ($5::text IS NULL OR severity = $5) \
+                   AND ($6::timestamptz IS NULL OR created_at >= $6) \
+                   AND ($7::timestamptz IS NULL OR created_at <= $7) \
+                 ORDER BY created_at DESC, id DESC LIMIT $8"
+            ))
             .bind(org_uuid)
             .bind(resource_type)
             .bind(resource_id)
+            .bind(user_uuid)
+            .bind(severity)
+            .bind(since)
+            .bind(until)
             .bind(limit + 1)
             .fetch_all(pool)
             .await
@@ -152,6 +247,72 @@ impl AuditRepo {
             rows.into_iter().map(AuditEvent::from).collect(),
             next_cursor,
         ))
+    }
+
+    /// Fetch all events in a date range for export (no pagination cap).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn list_for_export(
+        pool: &PgPool,
+        org_id: &str,
+        resource_type: Option<&str>,
+        user_id: Option<&str>,
+        severity: Option<&str>,
+        since: Option<OffsetDateTime>,
+        until: Option<OffsetDateTime>,
+    ) -> Result<Vec<AuditEvent>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let user_uuid = user_id.map(parse_uuid).transpose()?;
+
+        let rows: Vec<AuditRow> = sqlx::query_as(&format!(
+            "SELECT {COLS} FROM audit_events \
+             WHERE organization_id = $1 \
+               AND ($2::text IS NULL OR resource_type = $2) \
+               AND ($3::uuid IS NULL OR user_id = $3) \
+               AND ($4::text IS NULL OR severity = $4) \
+               AND ($5::timestamptz IS NULL OR created_at >= $5) \
+               AND ($6::timestamptz IS NULL OR created_at <= $6) \
+             ORDER BY created_at DESC \
+             LIMIT 100000"
+        ))
+        .bind(org_uuid)
+        .bind(resource_type)
+        .bind(user_uuid)
+        .bind(severity)
+        .bind(since)
+        .bind(until)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(rows.into_iter().map(AuditEvent::from).collect())
+    }
+
+    /// Compliance summary: event counts grouped by user, action, resource_type, severity.
+    pub async fn compliance_summary(
+        pool: &PgPool,
+        org_id: &str,
+        since: Option<OffsetDateTime>,
+        until: Option<OffsetDateTime>,
+    ) -> Result<Vec<ComplianceSummaryRow>, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+
+        let rows: Vec<SummaryRow> = sqlx::query_as(
+            "SELECT user_id, action, resource_type, severity, COUNT(*) AS event_count \
+             FROM audit_events \
+             WHERE organization_id = $1 \
+               AND ($2::timestamptz IS NULL OR created_at >= $2) \
+               AND ($3::timestamptz IS NULL OR created_at <= $3) \
+             GROUP BY user_id, action, resource_type, severity \
+             ORDER BY event_count DESC",
+        )
+        .bind(org_uuid)
+        .bind(since)
+        .bind(until)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
     }
 }
 

--- a/crates/db/src/repos/mod.rs
+++ b/crates/db/src/repos/mod.rs
@@ -125,7 +125,7 @@ pub use approval_chains::ApprovalChainRepo;
 pub use approval_rules::ApprovalRuleRepo;
 pub use assembly_orders::AssemblyOrderRepo;
 pub use attachments::AttachmentRepo;
-pub use audit::{AuditEvent, AuditRepo};
+pub use audit::{AuditEvent, AuditRepo, ComplianceSummaryRow};
 pub use bank::BankRepo;
 pub use bank_deposits::BankDepositRepo;
 pub use bank_feed::BankFeedRepo;


### PR DESCRIPTION
## Summary
- Adds `ip_address` (INET), `user_agent`, and `severity` (info/warning/critical) columns to `audit_events`
- Index on `(organization_id, user_id, created_at DESC)` for fast per-user queries
- Partial index on `(organization_id, severity, created_at DESC) WHERE severity <> 'info'` for warning/critical dashboards
- `AuditRepo::list` now accepts `user_id`, `severity`, `since`, `until` filters
- `AuditRepo::record_full` lets callers set severity and capture IP/UA
- New `list_for_export` (up to 100k rows) and `compliance_summary` (grouped counts)

## Endpoints
- `GET /audit-log` — paginated list with `?resource_type`, `?resource_id`, `?user_id`, `?severity`, `?since`, `?until`
- `GET /audit-log/export?format=csv|xlsx` — full export for compliance reporting (admin+)
- `GET /audit-log/compliance-summary?since=&until=` — aggregated counts by user/action/resource/severity (admin+)

## Test plan
- [ ] GET /audit-log?severity=critical returns only critical events
- [ ] GET /audit-log?user_id=<id> returns only events for that user
- [ ] GET /audit-log?since=2024-01-01T00:00:00Z filters by date
- [ ] GET /audit-log/export?format=xlsx returns valid XLSX file
- [ ] GET /audit-log/compliance-summary returns rows with event_count > 0
- [ ] Non-admin gets 403 on all three endpoints

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_