### PR TITLE
Sprint 82: Fixed asset depreciation schedules

### DIFF
--- a/crates/api/src/handlers/fixed_assets.rs
+++ b/crates/api/src/handlers/fixed_assets.rs
@@ -1,6 +1,7 @@
 use axum::{
-    extract::{Extension, Path, State},
+    extract::{Extension, Path, Query, State},
     http::StatusCode,
+    response::Response,
     Json,
 };
 use oxidebooks_core::models::{CreateFixedAsset, UpdateFixedAsset};
@@ -13,6 +14,7 @@ use crate::{
     error::{ApiError, ApiResult},
     middleware::Claims,
     state::AppState,
+    xlsx::{build_xlsx, XLSX_CONTENT_TYPE},
 };
 
 pub async fn list_fixed_assets(
@@ -112,4 +114,118 @@ pub async fn asset_register(
     }
     let rows = FixedAssetRepo::asset_register(&state.db, &claims.org).await?;
     Ok(Json(serde_json::json!({ "data": rows })))
+}
+
+pub async fn get_depreciation_schedule(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.has("fixed_assets:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let schedule = FixedAssetRepo::schedule(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": schedule })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExportQuery {
+    pub format: Option<String>,
+}
+
+pub async fn export_depreciation_schedule(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+    Query(q): Query<ExportQuery>,
+) -> ApiResult<Response> {
+    if !claims.has("fixed_assets:read") {
+        return Err(ApiError::Forbidden);
+    }
+    let asset = FixedAssetRepo::get_by_id(&state.db, &claims.org, &id).await?;
+    let schedule = FixedAssetRepo::schedule(&state.db, &claims.org, &id).await?;
+
+    let headers = &[
+        "Period",
+        "Date",
+        "Depreciation",
+        "Accumulated Depreciation",
+        "Book Value",
+        "Posted",
+    ];
+
+    let rows: Vec<Vec<String>> = schedule
+        .iter()
+        .map(|l| {
+            vec![
+                l.period.to_string(),
+                l.period_date.to_string(),
+                format!("{:.2}", l.amount as f64 / 100.0),
+                format!("{:.2}", l.accumulated_depreciation as f64 / 100.0),
+                format!("{:.2}", l.book_value as f64 / 100.0),
+                if l.is_posted { "Yes" } else { "No" }.to_string(),
+            ]
+        })
+        .collect();
+
+    let filename = format!("depreciation-schedule-{}.xlsx", asset.asset_number);
+
+    match q.format.as_deref() {
+        Some("xlsx") => {
+            let bytes = build_xlsx(
+                &format!("Schedule {}", asset.asset_number),
+                headers,
+                &rows,
+                &[2, 3, 4],
+            );
+            Ok(Response::builder()
+                .header("Content-Type", XLSX_CONTENT_TYPE)
+                .header(
+                    "Content-Disposition",
+                    format!("attachment; filename=\"{filename}\""),
+                )
+                .body(axum::body::Body::from(bytes))
+                .unwrap())
+        }
+        _ => {
+            let mut csv = headers.join(",") + "\n";
+            for row in &rows {
+                let line = row
+                    .iter()
+                    .map(|v| format!("\"{}\"", v.replace('"', "\"\"")))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                csv.push_str(&line);
+                csv.push('\n');
+            }
+            let csv_filename = filename.replace(".xlsx", ".csv");
+            Ok(Response::builder()
+                .header("Content-Type", "text/csv")
+                .header(
+                    "Content-Disposition",
+                    format!("attachment; filename=\"{csv_filename}\""),
+                )
+                .body(axum::body::Body::from(csv))
+                .unwrap())
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BulkDepreciateBody {
+    pub period_date: String,
+}
+
+pub async fn bulk_depreciate(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Json(body): Json<BulkDepreciateBody>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let period = Date::parse(&body.period_date, &Iso8601::DEFAULT)
+        .map_err(|_| ApiError::BadRequest("invalid period_date, expected YYYY-MM-DD".into()))?;
+    let result = FixedAssetRepo::bulk_depreciate(&state.db, &claims.org, period).await?;
+    Ok(Json(serde_json::json!({ "data": result })))
 }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -788,6 +788,18 @@ pub fn build(state: AppState) -> Router {
             post(fixed_assets::dispose_asset),
         )
         .route("/fixed-assets/register", get(fixed_assets::asset_register))
+        .route(
+            "/fixed-assets/depreciate-all",
+            post(fixed_assets::bulk_depreciate),
+        )
+        .route(
+            "/fixed-assets/:id/schedule",
+            get(fixed_assets::get_depreciation_schedule),
+        )
+        .route(
+            "/fixed-assets/:id/schedule/export",
+            get(fixed_assets::export_depreciation_schedule),
+        )
         // Projects
         .route(
             "/projects",

--- a/crates/core/src/models/fixed_asset.rs
+++ b/crates/core/src/models/fixed_asset.rs
@@ -8,6 +8,7 @@ use crate::models::opt_date_serde;
 pub enum DepreciationMethod {
     StraightLine,
     DecliningBalance,
+    SumOfYearsDigits,
 }
 
 impl std::fmt::Display for DepreciationMethod {
@@ -15,6 +16,7 @@ impl std::fmt::Display for DepreciationMethod {
         f.write_str(match self {
             DepreciationMethod::StraightLine => "straight_line",
             DepreciationMethod::DecliningBalance => "declining_balance",
+            DepreciationMethod::SumOfYearsDigits => "sum_of_years_digits",
         })
     }
 }
@@ -25,9 +27,29 @@ impl std::str::FromStr for DepreciationMethod {
         match s {
             "straight_line" => Ok(Self::StraightLine),
             "declining_balance" => Ok(Self::DecliningBalance),
+            "sum_of_years_digits" => Ok(Self::SumOfYearsDigits),
             _ => Err(()),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepreciationScheduleLine {
+    pub period: i32,
+    #[serde(with = "crate::models::date_serde")]
+    pub period_date: Date,
+    pub amount: i64,
+    pub accumulated_depreciation: i64,
+    pub book_value: i64,
+    pub is_posted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkDepreciationResult {
+    pub period_date: String,
+    pub processed: usize,
+    pub succeeded: usize,
+    pub skipped: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -206,7 +206,8 @@ pub use expense_report::{
     AddExpenseToReport, CreateExpenseReport, ExpenseReport, UpdateExpenseReport,
 };
 pub use fixed_asset::{
-    AssetRegisterRow, CreateFixedAsset, DepreciationMethod, FixedAsset, UpdateFixedAsset,
+    AssetRegisterRow, BulkDepreciationResult, CreateFixedAsset, DepreciationMethod,
+    DepreciationScheduleLine, FixedAsset, UpdateFixedAsset,
 };
 pub use fx::{FxSummaryRow, RealizedFxEntry};
 pub use fx_revaluation::{CreateFxRevaluation, FxRevaluation};

--- a/crates/db/migrations/0146_depreciation_schedule.sql
+++ b/crates/db/migrations/0146_depreciation_schedule.sql
@@ -1,0 +1,17 @@
+-- Extend depreciation methods to include sum-of-years-digits
+
+ALTER TABLE fixed_assets
+    DROP CONSTRAINT fixed_assets_depreciation_method_check;
+
+ALTER TABLE fixed_assets
+    ADD CONSTRAINT fixed_assets_depreciation_method_check
+        CHECK (depreciation_method IN (
+            'straight_line',
+            'declining_balance',
+            'sum_of_years_digits'
+        ));
+
+-- Index to support bulk-depreciation queries (active assets per org)
+CREATE INDEX IF NOT EXISTS idx_fixed_assets_org_active
+    ON fixed_assets (organization_id)
+    WHERE status = 'active';

--- a/crates/db/src/repos/fixed_assets.rs
+++ b/crates/db/src/repos/fixed_assets.rs
@@ -1,9 +1,10 @@
 use oxidebooks_core::models::{
-    AssetRegisterRow, CreateFixedAsset, DepreciationMethod, FixedAsset, UpdateFixedAsset,
+    AssetRegisterRow, BulkDepreciationResult, CreateFixedAsset, DepreciationMethod,
+    DepreciationScheduleLine, FixedAsset, UpdateFixedAsset,
 };
 use sqlx::PgPool;
 use std::str::FromStr;
-use time::{Date, OffsetDateTime};
+use time::{Date, Month, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::error::{map_sqlx_err, DbError};
@@ -219,7 +220,7 @@ impl FixedAssetRepo {
         Self::get_by_id(pool, org_id, id).await
     }
 
-    /// Record a monthly depreciation entry and optionally create a journal entry.
+    /// Record a monthly depreciation entry.
     pub async fn depreciate(
         pool: &PgPool,
         org_id: &str,
@@ -231,14 +232,37 @@ impl FixedAssetRepo {
             return Err(DbError::Conflict("asset is not active".into()));
         }
 
+        let n = asset.useful_life_months as i64;
         let depreciable = asset.purchase_cost - asset.salvage_value;
+
+        // For SYD we need to know which period number we're on.
+        let period_num = if asset.depreciation_method == DepreciationMethod::SumOfYearsDigits {
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM asset_depreciation_entries WHERE asset_id = $1",
+            )
+            .bind(parse_uuid(id)?)
+            .fetch_one(pool)
+            .await
+            .map_err(map_sqlx_err)?;
+            count + 1
+        } else {
+            0
+        };
+
         let amount = match asset.depreciation_method {
-            DepreciationMethod::StraightLine => depreciable / asset.useful_life_months as i64,
+            DepreciationMethod::StraightLine => depreciable / n,
             DepreciationMethod::DecliningBalance => {
-                let rate_num = 2i64;
-                let rate_den = asset.useful_life_months as i64;
                 let book = asset.book_value;
-                (book * rate_num / rate_den).max(0)
+                (book * 2 / n).max(0)
+            }
+            DepreciationMethod::SumOfYearsDigits => {
+                let syd = n * (n + 1) / 2;
+                let remaining_periods = (n - period_num + 1).max(0);
+                if syd == 0 {
+                    0
+                } else {
+                    depreciable * remaining_periods / syd
+                }
             }
         };
 
@@ -299,6 +323,147 @@ impl FixedAssetRepo {
         Self::get_by_id(pool, org_id, id).await
     }
 
+    /// Generate the complete depreciation schedule (posted + projected future periods).
+    pub async fn schedule(
+        pool: &PgPool,
+        org_id: &str,
+        id: &str,
+    ) -> Result<Vec<DepreciationScheduleLine>, DbError> {
+        let asset = Self::get_by_id(pool, org_id, id).await?;
+        let asset_uuid = parse_uuid(id)?;
+
+        // Fetch posted entries keyed by date.
+        #[derive(sqlx::FromRow)]
+        struct EntryRow {
+            period_date: Date,
+            amount: i64,
+        }
+        let posted: Vec<EntryRow> = sqlx::query_as(
+            "SELECT period_date, amount FROM asset_depreciation_entries \
+             WHERE asset_id = $1 ORDER BY period_date",
+        )
+        .bind(asset_uuid)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let posted_map: std::collections::HashMap<Date, i64> =
+            posted.iter().map(|e| (e.period_date, e.amount)).collect();
+
+        let n = asset.useful_life_months as i64;
+        let depreciable = asset.purchase_cost - asset.salvage_value;
+        let syd = n * (n + 1) / 2;
+        let start = first_of_month(asset.purchase_date);
+
+        let mut lines = Vec::with_capacity(asset.useful_life_months as usize);
+        let mut accumulated: i64 = 0;
+
+        for period in 1..=asset.useful_life_months as i64 {
+            let date = add_months(start, (period - 1) as i32);
+            let is_posted = posted_map.contains_key(&date);
+
+            let amount = if is_posted {
+                *posted_map.get(&date).unwrap()
+            } else {
+                // Project: compute what the amount would be.
+                let projected = match asset.depreciation_method {
+                    DepreciationMethod::StraightLine => depreciable / n,
+                    DepreciationMethod::DecliningBalance => {
+                        let book = (depreciable - accumulated).max(0);
+                        (book * 2 / n).max(0)
+                    }
+                    DepreciationMethod::SumOfYearsDigits => {
+                        let remaining = (n - period + 1).max(0);
+                        if syd == 0 {
+                            0
+                        } else {
+                            depreciable * remaining / syd
+                        }
+                    }
+                };
+                let remaining_depreciable = (depreciable - accumulated).max(0);
+                projected.min(remaining_depreciable).max(0)
+            };
+
+            accumulated += amount;
+            let book_value = (asset.purchase_cost - accumulated).max(asset.salvage_value);
+
+            lines.push(DepreciationScheduleLine {
+                period: period as i32,
+                period_date: date,
+                amount,
+                accumulated_depreciation: accumulated,
+                book_value,
+                is_posted,
+            });
+
+            if accumulated >= depreciable {
+                break;
+            }
+        }
+
+        Ok(lines)
+    }
+
+    /// Depreciate all active assets for a given period. Skips already-posted periods.
+    pub async fn bulk_depreciate(
+        pool: &PgPool,
+        org_id: &str,
+        period_date: Date,
+    ) -> Result<BulkDepreciationResult, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+        let asset_ids: Vec<Uuid> = sqlx::query_scalar(
+            "SELECT id FROM fixed_assets WHERE organization_id = $1 AND status = 'active'",
+        )
+        .bind(org_uuid)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let processed = asset_ids.len();
+        let mut succeeded = 0usize;
+        let mut skipped = 0usize;
+
+        for asset_id in asset_ids {
+            let id_str = asset_id.to_string();
+            let asset = Self::get_by_id(pool, org_id, &id_str).await?;
+
+            // Skip if already fully depreciated.
+            if asset.book_value <= asset.salvage_value {
+                skipped += 1;
+                continue;
+            }
+
+            // Check if this period is already posted.
+            let already: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM asset_depreciation_entries \
+                 WHERE asset_id = $1 AND period_date = $2)",
+            )
+            .bind(asset_id)
+            .bind(period_date)
+            .fetch_one(pool)
+            .await
+            .map_err(map_sqlx_err)?;
+
+            if already {
+                skipped += 1;
+                continue;
+            }
+
+            match Self::depreciate(pool, org_id, &id_str, period_date).await {
+                Ok(_) => succeeded += 1,
+                Err(_) => skipped += 1,
+            }
+        }
+
+        Ok(BulkDepreciationResult {
+            period_date: period_date.to_string(),
+            processed,
+            succeeded,
+            skipped,
+        })
+    }
+
     pub async fn asset_register(
         pool: &PgPool,
         org_id: &str,
@@ -334,4 +499,15 @@ impl FixedAssetRepo {
             })
             .collect())
     }
+}
+
+fn first_of_month(date: Date) -> Date {
+    Date::from_calendar_date(date.year(), date.month(), 1).expect("valid date")
+}
+
+fn add_months(date: Date, months: i32) -> Date {
+    let total = date.month() as i32 - 1 + months;
+    let year = date.year() + total.div_euclid(12);
+    let month = Month::try_from((total.rem_euclid(12) + 1) as u8).expect("valid month");
+    Date::from_calendar_date(year, month, 1).expect("valid date")
 }


### PR DESCRIPTION
## Summary

- **Sum-of-years-digits (SYD)** depreciation method added alongside existing straight-line and declining-balance; migration 0146 extends the CHECK constraint and adds a partial index on active assets
- **Full depreciation schedule projection** (`GET /fixed-assets/:id/schedule`): blends already-posted DB entries (`is_posted: true`) with projected future periods for all three methods, stopping when fully depreciated
- **Schedule export** (`GET /fixed-assets/:id/schedule/export?format=xlsx|csv`): download as XLSX (with numeric column hints) or CSV
- **Bulk depreciation run** (`POST /fixed-assets/depreciate-all`): single call to post the period's depreciation for every active, not-yet-posted, not-fully-depreciated asset; returns `{ processed, succeeded, skipped }`

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] Create a SYD asset, call `/depreciate` for several periods, verify amounts follow SYD formula
- [ ] `GET /fixed-assets/:id/schedule` returns N lines with correct `is_posted` flags and projected future amounts
- [ ] `GET /fixed-assets/:id/schedule/export?format=xlsx` downloads a valid XLSX file
- [ ] `POST /fixed-assets/depreciate-all` with `{"period_date": "2026-05-01"}` processes all active assets and returns correct counts

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_