### PR TITLE
feat(sprint-89): subscription analytics — MRR/ARR snapshot and churn report

### DIFF
--- a/crates/api/src/handlers/subscriptions.rs
+++ b/crates/api/src/handlers/subscriptions.rs
@@ -170,6 +170,65 @@ pub async fn bill_subscription(
 }
 
 #[derive(Deserialize)]
+pub struct MrrQuery {
+    pub as_of: Option<String>,
+}
+
+/// GET /api/v1/reports/subscription-mrr
+pub async fn subscription_mrr(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<MrrQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let as_of = if let Some(s) = q.as_of.as_deref() {
+        let fmt = time::macros::format_description!("[year]-[month]-[day]");
+        time::Date::parse(s, fmt)
+            .map_err(|_| ApiError::BadRequest(format!("invalid date '{s}'; expected YYYY-MM-DD")))?
+    } else {
+        time::OffsetDateTime::now_utc().date()
+    };
+    let snapshot = SubscriptionRepo::mrr_snapshot(&state.db, &claims.org, as_of).await?;
+    Ok(Json(serde_json::json!({ "data": snapshot })))
+}
+
+#[derive(Deserialize)]
+pub struct ChurnQuery {
+    pub from: Option<String>,
+    pub to: Option<String>,
+}
+
+/// GET /api/v1/reports/subscription-churn
+pub async fn subscription_churn(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Query(q): Query<ChurnQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let fmt = time::macros::format_description!("[year]-[month]-[day]");
+    let today = time::OffsetDateTime::now_utc().date();
+    let to = if let Some(s) = q.to.as_deref() {
+        time::Date::parse(s, fmt)
+            .map_err(|_| ApiError::BadRequest(format!("invalid date '{s}'; expected YYYY-MM-DD")))?
+    } else {
+        today
+    };
+    let from = if let Some(s) = q.from.as_deref() {
+        time::Date::parse(s, fmt)
+            .map_err(|_| ApiError::BadRequest(format!("invalid date '{s}'; expected YYYY-MM-DD")))?
+    } else {
+        // default: last 30 days
+        to - time::Duration::days(30)
+    };
+    let report = SubscriptionRepo::churn_report(&state.db, &claims.org, from, to).await?;
+    Ok(Json(serde_json::json!({ "data": report })))
+}
+
+#[derive(Deserialize)]
 pub struct BillingRunQuery {
     pub as_of: Option<String>,
 }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1927,6 +1927,14 @@ pub fn build(state: AppState) -> Router {
         .route("/reports/project-burn", get(reports::project_burn))
         .route("/reports/financial-ratios", get(reports::financial_ratios))
         .route("/reports/kpi-trends", get(reports::kpi_trends))
+        .route(
+            "/reports/subscription-mrr",
+            get(subscriptions::subscription_mrr),
+        )
+        .route(
+            "/reports/subscription-churn",
+            get(subscriptions::subscription_churn),
+        )
         // Inventory serial number tracking
         .route(
             "/inventory-serial-numbers",

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -360,8 +360,8 @@ pub use sales_tax_nexus::{CreateSalesTaxNexus, SalesTaxNexus, UpdateSalesTaxNexu
 pub use service_territory::{CreateServiceTerritory, ServiceTerritory, UpdateServiceTerritory};
 pub use session::Session;
 pub use subscription::{
-    CreateSubscription, CreateSubscriptionPlan, Subscription, SubscriptionPlan, UpdateSubscription,
-    UpdateSubscriptionPlan,
+    ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot, Subscription,
+    SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
 };
 pub use tag::{CreateTag, Tag, UpdateTag};
 pub use tax_filing::{HstGstReturn, T4AFilingSummary, T4ASlip, T4Slip, T4Summary, TaxFiling};

--- a/crates/core/src/models/subscription.rs
+++ b/crates/core/src/models/subscription.rs
@@ -94,3 +94,45 @@ fn default_cycle() -> String {
 fn default_quantity() -> i32 {
     1
 }
+
+/// MRR snapshot at a point in time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MrrSnapshot {
+    #[serde(with = "date_serde")]
+    pub as_of: Date,
+    /// Monthly Recurring Revenue (minor units, base currency).
+    pub mrr: MinorUnits,
+    /// Annual Recurring Revenue = MRR × 12.
+    pub arr: MinorUnits,
+    /// Number of active subscriptions contributing to MRR.
+    pub active_subscriptions: i64,
+    /// Breakdown by plan.
+    pub by_plan: Vec<MrrByPlan>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MrrByPlan {
+    pub plan_id: String,
+    pub plan_name: String,
+    pub billing_cycle: String,
+    pub active_count: i64,
+    pub mrr: MinorUnits,
+}
+
+/// Subscription churn analysis over a date range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChurnReport {
+    #[serde(with = "date_serde")]
+    pub from: Date,
+    #[serde(with = "date_serde")]
+    pub to: Date,
+    pub active_at_start: i64,
+    pub new_subscriptions: i64,
+    pub churned: i64,
+    /// Churned / (active_at_start + new). None if denominator is 0.
+    pub churn_rate_pct: Option<f64>,
+    pub net_new: i64,
+    pub churned_mrr: MinorUnits,
+    pub new_mrr: MinorUnits,
+    pub net_mrr_change: MinorUnits,
+}

--- a/crates/db/src/repos/subscriptions.rs
+++ b/crates/db/src/repos/subscriptions.rs
@@ -1,6 +1,6 @@
 use oxidebooks_core::models::{
-    CreateSubscription, CreateSubscriptionPlan, Subscription, SubscriptionPlan, UpdateSubscription,
-    UpdateSubscriptionPlan,
+    ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot, Subscription,
+    SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
 };
 use sqlx::PgPool;
 use time::{Date, OffsetDateTime};
@@ -513,6 +513,170 @@ impl SubscriptionRepo {
             failed_count: failed.len() as i64,
             invoice_ids: invoiced,
             failed_subscription_ids: failed,
+        })
+    }
+
+    /// Monthly Recurring Revenue snapshot as of a given date.
+    pub async fn mrr_snapshot(
+        pool: &PgPool,
+        org_id: &str,
+        as_of: Date,
+    ) -> Result<MrrSnapshot, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+
+        #[derive(sqlx::FromRow)]
+        struct PlanMrrRow {
+            plan_id: Uuid,
+            plan_name: String,
+            billing_cycle: String,
+            active_count: i64,
+            total_billing: i64,
+        }
+
+        let rows: Vec<PlanMrrRow> = sqlx::query_as(
+            "SELECT p.id AS plan_id, p.name AS plan_name, p.billing_cycle, \
+               COUNT(s.id) AS active_count, \
+               COALESCE(SUM(p.price * s.quantity), 0)::BIGINT AS total_billing \
+             FROM subscriptions s \
+             JOIN subscription_plans p ON p.id = s.plan_id \
+             WHERE s.organization_id = $1 \
+               AND s.status = 'active' \
+               AND s.current_period_start <= $2 \
+               AND s.current_period_end >= $2 \
+             GROUP BY p.id, p.name, p.billing_cycle",
+        )
+        .bind(org_uuid)
+        .bind(as_of)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let mut total_mrr: i64 = 0;
+        let mut total_active: i64 = 0;
+        let mut by_plan = Vec::new();
+
+        for r in rows {
+            let months = match r.billing_cycle.as_str() {
+                "quarterly" => 3i64,
+                "annual" | "yearly" => 12,
+                _ => 1,
+            };
+            let plan_mrr = r.total_billing / months;
+            total_mrr += plan_mrr;
+            total_active += r.active_count;
+            by_plan.push(MrrByPlan {
+                plan_id: r.plan_id.to_string(),
+                plan_name: r.plan_name,
+                billing_cycle: r.billing_cycle,
+                active_count: r.active_count,
+                mrr: plan_mrr,
+            });
+        }
+
+        by_plan.sort_by(|a, b| b.mrr.cmp(&a.mrr));
+
+        Ok(MrrSnapshot {
+            as_of,
+            mrr: total_mrr,
+            arr: total_mrr * 12,
+            active_subscriptions: total_active,
+            by_plan,
+        })
+    }
+
+    /// Churn analysis: new vs churned subscriptions and MRR impact over a date range.
+    pub async fn churn_report(
+        pool: &PgPool,
+        org_id: &str,
+        from: Date,
+        to: Date,
+    ) -> Result<ChurnReport, DbError> {
+        let org_uuid = parse_uuid(org_id)?;
+
+        // Active at start of period
+        let active_at_start: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM subscriptions s \
+             WHERE organization_id = $1 AND status IN ('active','trialing') \
+               AND current_period_start < $2 AND current_period_end >= $2",
+        )
+        .bind(org_uuid)
+        .bind(from)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        // New subscriptions in period
+        let new_subscriptions: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM subscriptions \
+             WHERE organization_id = $1 AND created_at::DATE >= $2 AND created_at::DATE <= $3",
+        )
+        .bind(org_uuid)
+        .bind(from)
+        .bind(to)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        // Churned in period
+        #[derive(sqlx::FromRow)]
+        struct ChurnRow {
+            churned: i64,
+            churned_mrr: i64,
+        }
+
+        let churn: ChurnRow = sqlx::query_as(
+            "SELECT COUNT(s.id) AS churned, \
+               COALESCE(SUM(p.price * s.quantity / \
+                 CASE p.billing_cycle \
+                   WHEN 'quarterly' THEN 3 WHEN 'annual' THEN 12 WHEN 'yearly' THEN 12 ELSE 1 \
+                 END), 0)::BIGINT AS churned_mrr \
+             FROM subscriptions s \
+             JOIN subscription_plans p ON p.id = s.plan_id \
+             WHERE s.organization_id = $1 AND s.status = 'cancelled' \
+               AND s.cancelled_at::DATE >= $2 AND s.cancelled_at::DATE <= $3",
+        )
+        .bind(org_uuid)
+        .bind(from)
+        .bind(to)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        // New MRR from new subscriptions in period
+        let new_mrr: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(p.price * s.quantity / \
+               CASE p.billing_cycle \
+                 WHEN 'quarterly' THEN 3 WHEN 'annual' THEN 12 WHEN 'yearly' THEN 12 ELSE 1 \
+               END), 0)::BIGINT \
+             FROM subscriptions s \
+             JOIN subscription_plans p ON p.id = s.plan_id \
+             WHERE s.organization_id = $1 AND s.created_at::DATE >= $2 AND s.created_at::DATE <= $3",
+        )
+        .bind(org_uuid)
+        .bind(from)
+        .bind(to)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let denominator = active_at_start + new_subscriptions;
+        let churn_rate_pct = if denominator > 0 {
+            Some(churn.churned as f64 / denominator as f64 * 100.0)
+        } else {
+            None
+        };
+
+        Ok(ChurnReport {
+            from,
+            to,
+            active_at_start,
+            new_subscriptions,
+            churned: churn.churned,
+            churn_rate_pct,
+            net_new: new_subscriptions - churn.churned,
+            churned_mrr: churn.churned_mrr,
+            new_mrr,
+            net_mrr_change: new_mrr - churn.churned_mrr,
         })
     }
 }

--- a/crates/db/src/repos/subscriptions.rs
+++ b/crates/db/src/repos/subscriptions.rs
@@ -556,12 +556,12 @@ impl SubscriptionRepo {
         let mut by_plan = Vec::new();
 
         for r in rows {
-            let months = match r.billing_cycle.as_str() {
-                "quarterly" => 3i64,
-                "annual" | "yearly" => 12,
-                _ => 1,
+            let plan_mrr = match r.billing_cycle.as_str() {
+                "weekly" => r.total_billing * 52 / 12,
+                "quarterly" => r.total_billing / 3,
+                "annually" => r.total_billing / 12,
+                _ => r.total_billing, // monthly
             };
-            let plan_mrr = r.total_billing / months;
             total_mrr += plan_mrr;
             total_active += r.active_count;
             by_plan.push(MrrByPlan {
@@ -626,10 +626,12 @@ impl SubscriptionRepo {
 
         let churn: ChurnRow = sqlx::query_as(
             "SELECT COUNT(s.id) AS churned, \
-               COALESCE(SUM(p.price * s.quantity / \
-                 CASE p.billing_cycle \
-                   WHEN 'quarterly' THEN 3 WHEN 'annual' THEN 12 WHEN 'yearly' THEN 12 ELSE 1 \
-                 END), 0)::BIGINT AS churned_mrr \
+               COALESCE(SUM(CASE p.billing_cycle \
+                 WHEN 'weekly'    THEN p.price * s.quantity * 52 / 12 \
+                 WHEN 'quarterly' THEN p.price * s.quantity / 3 \
+                 WHEN 'annually'  THEN p.price * s.quantity / 12 \
+                 ELSE                  p.price * s.quantity \
+               END), 0)::BIGINT AS churned_mrr \
              FROM subscriptions s \
              JOIN subscription_plans p ON p.id = s.plan_id \
              WHERE s.organization_id = $1 AND s.status = 'cancelled' \
@@ -644,10 +646,12 @@ impl SubscriptionRepo {
 
         // New MRR from new subscriptions in period
         let new_mrr: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(p.price * s.quantity / \
-               CASE p.billing_cycle \
-                 WHEN 'quarterly' THEN 3 WHEN 'annual' THEN 12 WHEN 'yearly' THEN 12 ELSE 1 \
-               END), 0)::BIGINT \
+            "SELECT COALESCE(SUM(CASE p.billing_cycle \
+               WHEN 'weekly'    THEN p.price * s.quantity * 52 / 12 \
+               WHEN 'quarterly' THEN p.price * s.quantity / 3 \
+               WHEN 'annually'  THEN p.price * s.quantity / 12 \
+               ELSE                  p.price * s.quantity \
+             END), 0)::BIGINT \
              FROM subscriptions s \
              JOIN subscription_plans p ON p.id = s.plan_id \
              WHERE s.organization_id = $1 AND s.created_at::DATE >= $2 AND s.created_at::DATE <= $3",


### PR DESCRIPTION
## Summary

- Add `MrrSnapshot`, `MrrByPlan`, and `ChurnReport` domain models to `oxidebooks-core`
- `SubscriptionRepo::mrr_snapshot` — joins active subscriptions with plans, normalises billing amount to monthly (÷1/3/12 for monthly/quarterly/annual), returns total MRR, ARR, active count, and per-plan breakdown sorted by MRR desc
- `SubscriptionRepo::churn_report` — computes active-at-start, new subscription count, churned count + churned MRR, new MRR, churn rate %, and net MRR change over a date range
- `GET /api/v1/reports/subscription-mrr?as_of=YYYY-MM-DD` — defaults to today
- `GET /api/v1/reports/subscription-churn?from=YYYY-MM-DD&to=YYYY-MM-DD` — defaults to last 30 days

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] `GET /reports/subscription-mrr` returns `{ "data": { mrr, arr, active_subscriptions, by_plan } }`
- [ ] `GET /reports/subscription-churn` returns `{ "data": { from, to, churned, churn_rate_pct, net_mrr_change, ... } }`
- [ ] Requires accountant role or above; returns 403 for viewer

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_