### PR TITLE
feat(sprint-90): subscription pause/resume and plan upgrade/downgrade

### DIFF
--- a/crates/api/src/handlers/subscriptions.rs
+++ b/crates/api/src/handlers/subscriptions.rs
@@ -4,7 +4,8 @@ use axum::{
     Json,
 };
 use oxidebooks_core::models::{
-    CreateSubscription, CreateSubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
+    ChangePlan, CreateSubscription, CreateSubscriptionPlan, UpdateSubscription,
+    UpdateSubscriptionPlan,
 };
 use oxidebooks_db::repos::{BillingRunResult, SubscriptionRepo};
 use serde::Deserialize;
@@ -138,6 +139,59 @@ pub async fn cancel_subscription(
     }
     let sub = SubscriptionRepo::cancel(&state.db, &claims.org, &id).await?;
     Ok(Json(serde_json::json!(sub)))
+}
+
+pub async fn pause_subscription(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let sub = SubscriptionRepo::pause(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": sub })))
+}
+
+pub async fn resume_subscription(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let sub = SubscriptionRepo::resume(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": sub })))
+}
+
+pub async fn change_subscription_plan(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+    Json(body): Json<ChangePlan>,
+) -> ApiResult<(StatusCode, Json<serde_json::Value>)> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let change =
+        SubscriptionRepo::change_plan(&state.db, &claims.org, &id, body, &claims.sub).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "data": change })),
+    ))
+}
+
+pub async fn list_subscription_plan_changes(
+    State(state): State<AppState>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if !claims.is_at_least_accountant() {
+        return Err(ApiError::Forbidden);
+    }
+    let changes = SubscriptionRepo::list_plan_changes(&state.db, &claims.org, &id).await?;
+    Ok(Json(serde_json::json!({ "data": changes })))
 }
 
 pub async fn renew_subscription(

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1865,6 +1865,23 @@ pub fn build(state: AppState) -> Router {
                 .patch(service_territories::update_service_territory)
                 .delete(service_territories::delete_service_territory),
         )
+        // Subscription lifecycle
+        .route(
+            "/subscriptions/:id/pause",
+            post(subscriptions::pause_subscription),
+        )
+        .route(
+            "/subscriptions/:id/resume",
+            post(subscriptions::resume_subscription),
+        )
+        .route(
+            "/subscriptions/:id/change-plan",
+            post(subscriptions::change_subscription_plan),
+        )
+        .route(
+            "/subscriptions/:id/plan-changes",
+            get(subscriptions::list_subscription_plan_changes),
+        )
         // Subscription billing
         .route(
             "/subscriptions/:id/bill",

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -360,8 +360,8 @@ pub use sales_tax_nexus::{CreateSalesTaxNexus, SalesTaxNexus, UpdateSalesTaxNexu
 pub use service_territory::{CreateServiceTerritory, ServiceTerritory, UpdateServiceTerritory};
 pub use session::Session;
 pub use subscription::{
-    ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot, Subscription,
-    SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
+    ChangePlan, ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot,
+    PlanChange, Subscription, SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
 };
 pub use tag::{CreateTag, Tag, UpdateTag};
 pub use tax_filing::{HstGstReturn, T4AFilingSummary, T4ASlip, T4Slip, T4Summary, TaxFiling};

--- a/crates/core/src/models/subscription.rs
+++ b/crates/core/src/models/subscription.rs
@@ -85,6 +85,27 @@ pub struct UpdateSubscription {
     pub notes: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ChangePlan {
+    pub new_plan_id: String,
+    /// If true, issue a prorated credit note for unused days on the old plan.
+    #[serde(default)]
+    pub prorate: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanChange {
+    pub id: String,
+    pub subscription_id: String,
+    pub old_plan_id: String,
+    pub new_plan_id: String,
+    pub old_price: MinorUnits,
+    pub new_price: MinorUnits,
+    pub proration_credit: MinorUnits,
+    #[serde(with = "time::serde::rfc3339")]
+    pub changed_at: OffsetDateTime,
+}
+
 fn default_currency() -> String {
     "USD".to_string()
 }

--- a/crates/db/migrations/0151_subscription_pause_plan_change.sql
+++ b/crates/db/migrations/0151_subscription_pause_plan_change.sql
@@ -1,0 +1,23 @@
+-- Sprint 90: subscription pause/resume and plan-change support
+
+-- Track when a subscription was paused
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS paused_at TIMESTAMPTZ;
+
+-- Log every plan change for audit and proration calculations
+CREATE TABLE IF NOT EXISTS subscription_plan_changes (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id  UUID NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    organization_id  UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    old_plan_id      UUID NOT NULL REFERENCES subscription_plans(id),
+    new_plan_id      UUID NOT NULL REFERENCES subscription_plans(id),
+    old_price        BIGINT NOT NULL,
+    new_price        BIGINT NOT NULL,
+    proration_credit BIGINT NOT NULL DEFAULT 0,
+    changed_by       UUID REFERENCES users(id) ON DELETE SET NULL,
+    changed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sub_plan_changes_sub
+    ON subscription_plan_changes(subscription_id, changed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sub_plan_changes_org
+    ON subscription_plan_changes(organization_id, changed_at DESC);

--- a/crates/db/migrations/0151_subscription_pause_plan_change.sql
+++ b/crates/db/migrations/0151_subscription_pause_plan_change.sql
@@ -1,5 +1,10 @@
 -- Sprint 90: subscription pause/resume and plan-change support
 
+-- Extend the status check to allow 'paused'
+ALTER TABLE subscriptions DROP CONSTRAINT IF EXISTS subscriptions_status_check;
+ALTER TABLE subscriptions ADD CONSTRAINT subscriptions_status_check
+    CHECK (status IN ('trialing','active','past_due','cancelled','expired','paused'));
+
 -- Track when a subscription was paused
 ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS paused_at TIMESTAMPTZ;
 

--- a/crates/db/src/repos/subscriptions.rs
+++ b/crates/db/src/repos/subscriptions.rs
@@ -1,6 +1,6 @@
 use oxidebooks_core::models::{
-    ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot, Subscription,
-    SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
+    ChangePlan, ChurnReport, CreateSubscription, CreateSubscriptionPlan, MrrByPlan, MrrSnapshot,
+    PlanChange, Subscription, SubscriptionPlan, UpdateSubscription, UpdateSubscriptionPlan,
 };
 use sqlx::PgPool;
 use time::{Date, OffsetDateTime};
@@ -682,6 +682,223 @@ impl SubscriptionRepo {
             new_mrr,
             net_mrr_change: new_mrr - churn.churned_mrr,
         })
+    }
+
+    /// Pause an active/trialing subscription. Billing is suspended until resumed.
+    pub async fn pause(pool: &PgPool, org_id: &str, id: &str) -> Result<Subscription, DbError> {
+        let org = parse_uuid(org_id)?;
+        let sid = parse_uuid(id)?;
+        let n = sqlx::query(
+            "UPDATE subscriptions
+             SET status = 'paused', paused_at = now(), updated_at = now()
+             WHERE organization_id = $1 AND id = $2
+               AND status IN ('active','trialing')",
+        )
+        .bind(org)
+        .bind(sid)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .rows_affected();
+        if n == 0 {
+            return Err(DbError::Conflict(
+                "subscription cannot be paused in its current state".into(),
+            ));
+        }
+        Self::get_by_id(pool, org_id, id).await
+    }
+
+    /// Resume a paused subscription. The billing period restarts from today.
+    pub async fn resume(pool: &PgPool, org_id: &str, id: &str) -> Result<Subscription, DbError> {
+        let org = parse_uuid(org_id)?;
+        let sid = parse_uuid(id)?;
+
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT p.billing_cycle FROM subscriptions s
+             JOIN subscription_plans p ON p.id = s.plan_id
+             WHERE s.organization_id = $1 AND s.id = $2 AND s.status = 'paused'",
+        )
+        .bind(org)
+        .bind(sid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let (billing_cycle,) = row.ok_or(DbError::NotFound)?;
+        let today = time::OffsetDateTime::now_utc().date();
+        let new_end = next_period_end(today, &billing_cycle);
+
+        sqlx::query(
+            "UPDATE subscriptions
+             SET status = 'active', paused_at = NULL,
+                 current_period_start = $3, current_period_end = $4,
+                 updated_at = now()
+             WHERE organization_id = $1 AND id = $2",
+        )
+        .bind(org)
+        .bind(sid)
+        .bind(today)
+        .bind(new_end)
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Self::get_by_id(pool, org_id, id).await
+    }
+
+    /// Change the subscription to a different plan (upgrade or downgrade).
+    /// If `input.prorate = true`, calculates unused days credit from the old plan.
+    pub async fn change_plan(
+        pool: &PgPool,
+        org_id: &str,
+        id: &str,
+        input: ChangePlan,
+        changed_by: &str,
+    ) -> Result<PlanChange, DbError> {
+        let org = parse_uuid(org_id)?;
+        let sid = parse_uuid(id)?;
+        let new_plan_id = parse_uuid(&input.new_plan_id)?;
+        let changer = parse_uuid(changed_by)?;
+
+        #[derive(sqlx::FromRow)]
+        struct SubPlanRow {
+            old_plan_id: Uuid,
+            old_price: i64,
+            period_start: Date,
+            period_end: Date,
+        }
+
+        let row: SubPlanRow = sqlx::query_as(
+            "SELECT s.plan_id AS old_plan_id, p.price AS old_price,
+                    s.current_period_start AS period_start,
+                    s.current_period_end   AS period_end
+             FROM subscriptions s
+             JOIN subscription_plans p ON p.id = s.plan_id
+             WHERE s.organization_id = $1 AND s.id = $2
+               AND s.status IN ('active','trialing','paused')",
+        )
+        .bind(org)
+        .bind(sid)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .ok_or(DbError::NotFound)?;
+
+        let new_price: i64 = sqlx::query_scalar(
+            "SELECT price FROM subscription_plans
+             WHERE organization_id = $1 AND id = $2 AND is_active = TRUE",
+        )
+        .bind(org)
+        .bind(new_plan_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_err)?
+        .ok_or(DbError::NotFound)?;
+
+        // Prorated credit = old daily rate × remaining days in current period
+        let proration_credit = if input.prorate {
+            let today = time::OffsetDateTime::now_utc().date();
+            let period_days = (row.period_end - row.period_start).whole_days().max(1);
+            let remaining_days = (row.period_end - today).whole_days().max(0);
+            row.old_price * remaining_days / period_days
+        } else {
+            0
+        };
+
+        let mut tx = pool.begin().await.map_err(map_sqlx_err)?;
+
+        sqlx::query(
+            "UPDATE subscriptions SET plan_id = $3, updated_at = now()
+             WHERE organization_id = $1 AND id = $2",
+        )
+        .bind(org)
+        .bind(sid)
+        .bind(new_plan_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        let change_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO subscription_plan_changes
+                (id, subscription_id, organization_id, old_plan_id, new_plan_id,
+                 old_price, new_price, proration_credit, changed_by)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(change_id)
+        .bind(sid)
+        .bind(org)
+        .bind(row.old_plan_id)
+        .bind(new_plan_id)
+        .bind(row.old_price)
+        .bind(new_price)
+        .bind(proration_credit)
+        .bind(changer)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        tx.commit().await.map_err(map_sqlx_err)?;
+
+        Ok(PlanChange {
+            id: change_id.to_string(),
+            subscription_id: sid.to_string(),
+            old_plan_id: row.old_plan_id.to_string(),
+            new_plan_id: new_plan_id.to_string(),
+            old_price: row.old_price,
+            new_price,
+            proration_credit,
+            changed_at: time::OffsetDateTime::now_utc(),
+        })
+    }
+
+    /// List the plan-change history for a subscription.
+    pub async fn list_plan_changes(
+        pool: &PgPool,
+        org_id: &str,
+        subscription_id: &str,
+    ) -> Result<Vec<PlanChange>, DbError> {
+        let org = parse_uuid(org_id)?;
+        let sid = parse_uuid(subscription_id)?;
+
+        #[derive(sqlx::FromRow)]
+        struct PlanChangeRow {
+            id: Uuid,
+            subscription_id: Uuid,
+            old_plan_id: Uuid,
+            new_plan_id: Uuid,
+            old_price: i64,
+            new_price: i64,
+            proration_credit: i64,
+            changed_at: OffsetDateTime,
+        }
+
+        let rows: Vec<PlanChangeRow> = sqlx::query_as(
+            "SELECT id, subscription_id, old_plan_id, new_plan_id,
+                    old_price, new_price, proration_credit, changed_at
+             FROM subscription_plan_changes
+             WHERE organization_id = $1 AND subscription_id = $2
+             ORDER BY changed_at DESC",
+        )
+        .bind(org)
+        .bind(sid)
+        .fetch_all(pool)
+        .await
+        .map_err(map_sqlx_err)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| PlanChange {
+                id: r.id.to_string(),
+                subscription_id: r.subscription_id.to_string(),
+                old_plan_id: r.old_plan_id.to_string(),
+                new_plan_id: r.new_plan_id.to_string(),
+                old_price: r.old_price,
+                new_price: r.new_price,
+                proration_credit: r.proration_credit,
+                changed_at: r.changed_at,
+            })
+            .collect())
     }
 }
 

--- a/crates/db/src/repos/subscriptions.rs
+++ b/crates/db/src/repos/subscriptions.rs
@@ -764,12 +764,13 @@ impl SubscriptionRepo {
         struct SubPlanRow {
             old_plan_id: Uuid,
             old_price: i64,
+            quantity: i32,
             period_start: Date,
             period_end: Date,
         }
 
         let row: SubPlanRow = sqlx::query_as(
-            "SELECT s.plan_id AS old_plan_id, p.price AS old_price,
+            "SELECT s.plan_id AS old_plan_id, p.price AS old_price, s.quantity,
                     s.current_period_start AS period_start,
                     s.current_period_end   AS period_end
              FROM subscriptions s
@@ -795,12 +796,12 @@ impl SubscriptionRepo {
         .map_err(map_sqlx_err)?
         .ok_or(DbError::NotFound)?;
 
-        // Prorated credit = old daily rate × remaining days in current period
+        // Prorated credit = old billing amount × (remaining days / period days)
         let proration_credit = if input.prorate {
             let today = time::OffsetDateTime::now_utc().date();
             let period_days = (row.period_end - row.period_start).whole_days().max(1);
             let remaining_days = (row.period_end - today).whole_days().max(0);
-            row.old_price * remaining_days / period_days
+            row.old_price * row.quantity as i64 * remaining_days / period_days
         } else {
             0
         };


### PR DESCRIPTION
## Summary

- **Pause/resume** — `POST /subscriptions/:id/pause` suspends an active/trialing subscription (status → `paused`, `paused_at` recorded); `POST /subscriptions/:id/resume` restores it to `active` with a fresh period starting today
- **Plan change** — `POST /subscriptions/:id/change-plan` switches to a new plan; optional `prorate: true` computes unused-days credit from the old plan's daily rate
- **Plan-change history** — `GET /subscriptions/:id/plan-changes` returns the full audit log from the new `subscription_plan_changes` table (migration 0151)
- New models: `ChangePlan` (request), `PlanChange` (response/audit record)

## Test plan

- [ ] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` all pass
- [ ] `POST /subscriptions/:id/pause` → status becomes `paused`; fails if already cancelled/paused
- [ ] `POST /subscriptions/:id/resume` → status becomes `active`, new period set from today; fails if not paused
- [ ] `POST /subscriptions/:id/change-plan` `{"new_plan_id":"...","prorate":false}` → returns `PlanChange` with `proration_credit=0`
- [ ] Same with `prorate: true` → `proration_credit` > 0 when days remain in period
- [ ] `GET /subscriptions/:id/plan-changes` → returns history array sorted by `changed_at` desc
- [ ] Requires accountant role; returns 403 for viewer

https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU1Ss98cdeebVsKx9pspg2)_